### PR TITLE
reasoning-budget: add multi-point budget mechanism (intro, soft warnings, grace, usage telemetry)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3717,6 +3717,50 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             }
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_REASONING_EFFORT"));
+    static auto unescape = [](const std::string & s) {
+        std::string r;
+        r.reserve(s.size());
+        for (size_t i = 0; i < s.size(); i++) {
+            if (s[i] == '\\' && i + 1 < s.size()) {
+                switch (s[i + 1]) {
+                    case 'n':
+                        r += '\n';
+                        i++;
+                        break;
+                    case 't':
+                        r += '\t';
+                        i++;
+                        break;
+                    case 'r':
+                        r += '\r';
+                        i++;
+                        break;
+                    case '\\':
+                        r += '\\';
+                        i++;
+                        break;
+                    case '"':
+                        r += '"';
+                        i++;
+                        break;
+                    default:
+                        r += s[i];
+                        break;
+                }
+            } else {
+                r += s[i];
+            }
+        }
+        return r;
+    };
+
+    add_opt(common_arg({ "--reasoning-budget-enable" }, { "--no-reasoning-budget-enable" },
+                       "enable the reasoning budget mechanism: hard cutoff, soft warning, intro message, grace "
+                       "period, and runtime reasoning control (default: disabled)",
+                       [](common_params & params, bool value) { params.sampling.reasoning_budget_enabled = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_ENABLE"));
+
     add_opt(common_arg(
         {"--reasoning-budget"}, "N",
         "token budget for thinking: -1 for unrestricted, 0 for immediate end, N>0 for token budget (default: -1)",
@@ -3725,13 +3769,68 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.sampling.reasoning_budget_tokens = value;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET"));
-    add_opt(common_arg(
-        {"--reasoning-budget-message"}, "MESSAGE",
-        "message injected before the end-of-thinking tag when reasoning budget is exhausted (default: none)",
-        [](common_params & params, const std::string & value) {
-            params.sampling.reasoning_budget_message = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET_MESSAGE"));
+    add_opt(common_arg({ "--reasoning-budget-message" }, "MESSAGE",
+                       "message forced when the reasoning budget is exhausted; include the closing tag because it is "
+                       "not appended automatically (default: none)",
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.reasoning_budget_message = unescape(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_MESSAGE"));
+    add_opt(common_arg({ "--reasoning-budget-soft-ratio" }, "N",
+                       "fraction of the budget consumed before the first soft warning: <= 0 disables it, "
+                       "(0,1] enables it (default: -1)",
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.reasoning_budget_soft_ratio = std::stof(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_SOFT_RATIO"));
+    add_opt(common_arg({ "--reasoning-budget-soft-message" }, "MESSAGE",
+                       "message forced at the first soft reasoning budget threshold (default: none)",
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.reasoning_budget_soft_message = unescape(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_SOFT_MESSAGE"));
+    add_opt(common_arg({ "--reasoning-budget-soft2-ratio" }, "N",
+                       "fraction of the budget consumed before the second soft warning: <= 0 disables it, "
+                       "(0,1] enables it (default: -1)",
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.reasoning_budget_soft2_ratio = std::stof(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_SOFT2_RATIO"));
+    add_opt(common_arg({ "--reasoning-budget-soft2-message" }, "MESSAGE",
+                       "message forced at the second soft reasoning budget threshold (default: none)",
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.reasoning_budget_soft2_message = unescape(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_SOFT2_MESSAGE"));
+    add_opt(common_arg({ "--reasoning-budget-intro-mode" }, "MODE",
+                       "force the intro message for every reasoning block or only once per conversation "
+                       "(default: every)",
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.reasoning_budget_intro_mode = value;
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_INTRO_MODE"));
+    add_opt(common_arg({ "--reasoning-budget-intro-message" }, "MESSAGE",
+                       string_format(
+                           "message forced when the reasoning block starts; use {budget} for the configured "
+                           "budget (default: '%s')",
+                           params.sampling.reasoning_budget_intro_message.c_str()),
+                       [](common_params & params, const std::string & value) {
+                           params.sampling.reasoning_budget_intro_message = unescape(value);
+                       })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_INTRO_MESSAGE"));
+    add_opt(common_arg({ "--reasoning-budget-grace-tokens" }, "N",
+                       "wait up to N tokens for a paragraph break before forcing the exhausted reasoning budget "
+                       "(default: 0, disabled)",
+                       [](common_params & params, int value) { params.sampling.reasoning_budget_grace_tokens = value; })
+                .set_examples({ LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI })
+                .set_env("LLAMA_ARG_THINK_BUDGET_GRACE_TOKENS"));
     add_opt(common_arg(
         {"--reasoning-preserve"},
         {"--no-reasoning-preserve"},

--- a/common/common.h
+++ b/common/common.h
@@ -286,12 +286,31 @@ struct common_params_sampling {
 
     // reasoning budget sampler parameters
     // these are populated by the server/CLI based on chat template params
+    bool reasoning_budget_enabled =
+        false;  // Master switch for the budget, soft warnings, intro, grace, and reasoning control.
     int32_t                   reasoning_budget_tokens   = -1;  // -1 = disabled, >= 0 = token budget
-    std::vector<llama_token>  reasoning_budget_start;          // start tag token sequence
-    std::vector<llama_tokens> reasoning_budget_end;            // end tag token sequences; the first tag is used as the forcing sequence
-    std::vector<llama_token>  reasoning_budget_forced;         // forced sequence (message + first end tag)
-    std::string               reasoning_budget_message;        // message injected before end tag when budget exhausted
-    bool                      reasoning_control = false;       // create the budget sampler on demand so reasoning can be ended at runtime
+    std::vector<llama_token>  reasoning_budget_start;          // Start tag token sequence.
+    std::vector<llama_tokens> reasoning_budget_end;            // End tag token sequences. First is forced.
+    std::vector<llama_token>  reasoning_budget_forced;         // Forced sequence: message and first end tag.
+    std::string               reasoning_budget_message;        // Message injected before the forced end tag.
+    bool                      reasoning_control = false;       // Create sampler for runtime reasoning control.
+
+    float reasoning_budget_soft_ratio = -1.0f;  // <= 0 disables the first soft warning.
+    std::vector<llama_token> reasoning_budget_soft_forced;
+    std::string              reasoning_budget_soft_message;
+
+    float                    reasoning_budget_soft2_ratio = -1.0f;
+    std::vector<llama_token> reasoning_budget_soft2_forced;
+    std::string              reasoning_budget_soft2_message;
+
+    std::vector<llama_token> reasoning_budget_intro_forced;
+    std::string reasoning_budget_intro_message =
+        "I'll keep this reasoning under {budget} tokens, so I'll stay focused and efficient. ";
+    std::string reasoning_budget_intro_mode =
+        "every";
+
+    int32_t reasoning_budget_grace_tokens =
+        0;  // <= 0 forces immediately. Positive values wait for a paragraph break.
 
     bool backend_sampling = false;
 

--- a/common/reasoning-budget.cpp
+++ b/common/reasoning-budget.cpp
@@ -36,7 +36,7 @@ struct token_matcher {
         return t;
     }
 
-    // returns the index into seqs of the longest sequence ending at this token, or -1
+    // Returns the index of the longest sequence ending at this token, or -1.
     int32_t advance(llama_token token) {
         state = ac.next(state, (uint32_t) token);
         const int32_t p = ac.match_pattern(state);
@@ -56,19 +56,88 @@ struct common_reasoning_budget_ctx {
     token_matcher end_matcher;
     llama_tokens forced_tokens;
 
-    int32_t budget;           // maximum tokens in reasoning block
-    int32_t remaining;        // tokens remaining in budget
+    int32_t budget;           // Maximum tokens in reasoning block.
+    int32_t remaining;        // Tokens remaining in budget.
 
     common_reasoning_budget_state state;
 
-    // for forcing
-    size_t force_pos;         // next position in forced_tokens to force
+    size_t force_pos;         // Next position in forced_tokens to force.
 
-    int32_t end_match;        // index into end_matcher.seqs of the sequence that transitioned to DONE, -1 if none
+    int32_t end_match;        // Index into end_matcher.seqs that transitioned to DONE, or -1.
+
+    struct soft_point_state {
+        int32_t      threshold;
+        llama_tokens tokens;
+        bool         triggered;
+        size_t       force_pos;
+    };
+
+    std::vector<soft_point_state> soft_points;
+    size_t                        active_soft;
+
+    llama_tokens intro_forced_tokens;
+    size_t       intro_force_pos;
+
+    int32_t grace_tokens;
+    int32_t grace_remaining;
+    bool    hard_pending_prev_nl;
 };
 
 static const char * common_reasoning_budget_name(const struct llama_sampler * /*smpl*/) {
     return "reasoning-budget";
+}
+
+static bool token_utf8_complete(const common_reasoning_budget_ctx * ctx, llama_token token) {
+    if (ctx->vocab == nullptr) {
+        return true;
+    }
+    const std::string piece = common_token_to_piece(ctx->vocab, token, false);
+    return common_utf8_is_complete(piece);
+}
+
+static void common_reasoning_budget_begin_forcing(common_reasoning_budget_ctx * ctx, llama_token token) {
+    ctx->end_matcher.reset();
+    if (token_utf8_complete(ctx, token)) {
+        ctx->state     = REASONING_BUDGET_FORCING;
+        ctx->force_pos = 0;
+    } else {
+        ctx->state = REASONING_BUDGET_WAITING_UTF8;
+    }
+}
+
+static void common_reasoning_budget_enter_hard_exhausted(common_reasoning_budget_ctx * ctx, llama_token token) {
+    if (ctx->grace_tokens > 0) {
+        ctx->state                = REASONING_BUDGET_HARD_PENDING;
+        ctx->grace_remaining      = ctx->grace_tokens;
+        ctx->hard_pending_prev_nl = false;
+        ctx->end_matcher.reset();
+        COM_TRC("budget exhausted, waiting up to %d tokens for a paragraph break\n", ctx->grace_tokens);
+        return;
+    }
+
+    common_reasoning_budget_begin_forcing(ctx, token);
+    COM_TRC("%s", "budget exhausted, forcing end sequence\n");
+}
+
+static void common_reasoning_budget_activate(common_reasoning_budget_ctx * ctx) {
+    ctx->remaining = ctx->budget;
+    for (auto & sp : ctx->soft_points) {
+        sp.triggered = false;
+    }
+    ctx->end_match = -1;
+
+    if (!ctx->intro_forced_tokens.empty()) {
+        ctx->state           = REASONING_BUDGET_INTRO_FORCING;
+        ctx->intro_force_pos = 0;
+        COM_TRC("activated, budget=%d tokens, forcing intro message\n", ctx->budget);
+    } else if (ctx->remaining <= 0) {
+        ctx->state     = REASONING_BUDGET_FORCING;
+        ctx->force_pos = 0;
+        COM_TRC("%s", "budget=0, forcing immediately\n");
+    } else {
+        ctx->state = REASONING_BUDGET_COUNTING;
+        COM_TRC("activated, budget=%d tokens\n", ctx->budget);
+    }
 }
 
 static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_token token) {
@@ -78,20 +147,24 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
         case REASONING_BUDGET_IDLE:
         {
             if (ctx->start_matcher.advance(token) >= 0) {
-                ctx->state = REASONING_BUDGET_COUNTING;
-                ctx->remaining = ctx->budget;
-                COM_TRC("activated, budget=%d tokens\n", ctx->budget);
-
-                if (ctx->remaining <= 0) {
-                    ctx->state = REASONING_BUDGET_FORCING;
-                    ctx->force_pos = 0;
-                    COM_TRC("%s", "budget=0, forcing immediately\n");
-                }
+                common_reasoning_budget_activate(ctx);
             }
             break;
         }
+        case REASONING_BUDGET_INTRO_FORCING:
+            ctx->intro_force_pos++;
+            if (ctx->intro_force_pos >= ctx->intro_forced_tokens.size()) {
+                if (ctx->remaining <= 0) {
+                    ctx->state = REASONING_BUDGET_FORCING;
+                    ctx->force_pos = 0;
+                    COM_TRC("%s", "intro complete, budget=0, forcing immediately\n");
+                } else {
+                    ctx->state = REASONING_BUDGET_COUNTING;
+                    COM_TRC("%s", "intro complete, resuming countdown\n");
+                }
+            }
+            break;
         case REASONING_BUDGET_COUNTING:
-        case REASONING_BUDGET_WAITING_UTF8:
         {
             const int32_t match = ctx->end_matcher.advance(token);
             if (match >= 0) {
@@ -101,39 +174,109 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
                 break;
             }
 
-            bool utf8_complete = true;
-            if (ctx->vocab != nullptr) {
-                const std::string piece = common_token_to_piece(ctx->vocab, token, false);
-                utf8_complete = common_utf8_is_complete(piece);
+            ctx->remaining--;
+            if (ctx->remaining <= 0) {
+                common_reasoning_budget_enter_hard_exhausted(ctx, token);
+                break;
             }
 
-            if (ctx->state == REASONING_BUDGET_WAITING_UTF8) {
-                if (utf8_complete) {
-                    ctx->state = REASONING_BUDGET_FORCING;
-                    ctx->force_pos = 0;
-                    ctx->end_matcher.reset();
-                    COM_TRC("%s", "UTF-8 complete, now forcing end sequence\n");
+            for (size_t i = 0; i < ctx->soft_points.size(); i++) {
+                auto & sp = ctx->soft_points[i];
+                if (!sp.triggered && ctx->remaining <= sp.threshold) {
+                    ctx->active_soft = i;
+                    ctx->state       = REASONING_BUDGET_SOFT_PENDING;
+                    COM_TRC("soft threshold reached (remaining=%d, point %zu), waiting for newline\n", ctx->remaining,
+                            i);
+                    break;
                 }
-            } else if (ctx->state == REASONING_BUDGET_COUNTING) {
-                ctx->remaining--;
-                if (ctx->remaining <= 0) {
-                    if (utf8_complete) {
-                        ctx->state = REASONING_BUDGET_FORCING;
-                        ctx->force_pos = 0;
-                        ctx->end_matcher.reset();
-                        COM_TRC("%s", "budget exhausted, forcing end sequence\n");
-                    } else {
-                        ctx->state = REASONING_BUDGET_WAITING_UTF8;
-                        ctx->end_matcher.reset();
-                        COM_TRC("%s", "budget exhausted, waiting for UTF-8 completion\n");
-                    }
+            }
+            break;
+        }
+        case REASONING_BUDGET_SOFT_PENDING:
+        {
+            const int32_t match = ctx->end_matcher.advance(token);
+            if (match >= 0) {
+                ctx->state     = REASONING_BUDGET_DONE;
+                ctx->end_match = match;
+                COM_TRC("%s", "deactivated (natural end)\n");
+                break;
+            }
+
+            ctx->remaining--;
+            if (ctx->remaining <= 0) {
+                COM_TRC("%s", "budget exhausted before newline, soft warning skipped\n");
+                common_reasoning_budget_enter_hard_exhausted(ctx, token);
+                break;
+            }
+
+            if (ctx->vocab != nullptr) {
+                const std::string piece = common_token_to_piece(ctx->vocab, token, false);
+                if (piece.find('\n') != std::string::npos) {
+                    ctx->state   = REASONING_BUDGET_SOFT_FORCING;
+                    auto & sp    = ctx->soft_points[ctx->active_soft];
+                    sp.force_pos = 0;
+                    sp.triggered = true;
+                    COM_TRC("%s", "newline boundary found, forcing soft warning\n");
                 }
+            }
+            break;
+        }
+        case REASONING_BUDGET_SOFT_FORCING:
+        {
+            auto & sp = ctx->soft_points[ctx->active_soft];
+            sp.force_pos++;
+            if (sp.force_pos >= sp.tokens.size()) {
+                ctx->state = REASONING_BUDGET_COUNTING;
+                COM_TRC("%s", "soft warning complete, resuming countdown\n");
+            }
+            break;
+        }
+        case REASONING_BUDGET_HARD_PENDING:
+        {
+            const int32_t match = ctx->end_matcher.advance(token);
+            if (match >= 0) {
+                ctx->state     = REASONING_BUDGET_DONE;
+                ctx->end_match = match;
+                COM_TRC("%s", "deactivated (natural end)\n");
+                break;
+            }
+
+            ctx->grace_remaining--;
+
+            const std::string piece =
+                ctx->vocab != nullptr ? common_token_to_piece(ctx->vocab, token, false) : std::string();
+            const bool paragraph_boundary = piece.find("\n\n") != std::string::npos ||
+                                            (ctx->hard_pending_prev_nl && !piece.empty() && piece[0] == '\n');
+            ctx->hard_pending_prev_nl     = !piece.empty() && piece.back() == '\n';
+
+            if (paragraph_boundary) {
+                common_reasoning_budget_begin_forcing(ctx, token);
+                COM_TRC("%s", "paragraph boundary found, forcing end sequence\n");
+            } else if (ctx->grace_remaining <= 0) {
+                common_reasoning_budget_begin_forcing(ctx, token);
+                COM_TRC("%s", "grace period expired, forcing end sequence\n");
+            }
+            break;
+        }
+        case REASONING_BUDGET_WAITING_UTF8:
+        {
+            const int32_t match = ctx->end_matcher.advance(token);
+            if (match >= 0) {
+                ctx->state     = REASONING_BUDGET_DONE;
+                ctx->end_match = match;
+                COM_TRC("%s", "deactivated (natural end)\n");
+                break;
+            }
+
+            if (token_utf8_complete(ctx, token)) {
+                common_reasoning_budget_begin_forcing(ctx, token);
+                COM_TRC("%s", "UTF-8 complete, now forcing end sequence\n");
             }
             break;
         }
         case REASONING_BUDGET_FORCING:
         {
-            // track the end sequence within forced_tokens so it is also reported on DONE
+            // Track the end sequence in forced_tokens for grammar replay.
             const int32_t match = ctx->end_matcher.advance(token);
             ctx->force_pos++;
             if (ctx->force_pos >= ctx->forced_tokens.size()) {
@@ -144,20 +287,9 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
             break;
         }
         case REASONING_BUDGET_DONE:
-            // Re-arm on a new start tag: some models emit multiple <think> blocks
-            // per response, and each should get a fresh budget window.
             if (ctx->start_matcher.advance(token) >= 0) {
-                ctx->state = REASONING_BUDGET_COUNTING;
-                ctx->remaining = ctx->budget;
                 ctx->end_matcher.reset();
-                ctx->end_match = -1;
-                COM_TRC("re-activated on new start tag, budget=%d tokens\n", ctx->budget);
-
-                if (ctx->remaining <= 0) {
-                    ctx->state = REASONING_BUDGET_FORCING;
-                    ctx->force_pos = 0;
-                    COM_TRC("%s", "budget=0, forcing immediately\n");
-                }
+                common_reasoning_budget_activate(ctx);
             }
             break;
     }
@@ -166,18 +298,28 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
 static void common_reasoning_budget_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
     auto * ctx = (common_reasoning_budget_ctx *) smpl->ctx;
 
-    if (ctx->state != REASONING_BUDGET_FORCING) {
-        // passthrough — don't modify logits
+    llama_token forced;
+
+    if (ctx->state == REASONING_BUDGET_FORCING) {
+        if (ctx->force_pos >= ctx->forced_tokens.size()) {
+            return;
+        }
+        forced = ctx->forced_tokens[ctx->force_pos];
+    } else if (ctx->state == REASONING_BUDGET_SOFT_FORCING) {
+        const auto & sp = ctx->soft_points[ctx->active_soft];
+        if (sp.force_pos >= sp.tokens.size()) {
+            return;
+        }
+        forced = sp.tokens[sp.force_pos];
+    } else if (ctx->state == REASONING_BUDGET_INTRO_FORCING) {
+        if (ctx->intro_force_pos >= ctx->intro_forced_tokens.size()) {
+            return;
+        }
+        forced = ctx->intro_forced_tokens[ctx->intro_force_pos];
+    } else {
         return;
     }
 
-    if (ctx->force_pos >= ctx->forced_tokens.size()) {
-        return;
-    }
-
-    const llama_token forced = ctx->forced_tokens[ctx->force_pos];
-
-    // set all logits to -inf except the forced token
     for (size_t i = 0; i < cur_p->size; i++) {
         if (cur_p->data[i].id != forced) {
             cur_p->data[i].logit = -INFINITY;
@@ -193,12 +335,26 @@ static void common_reasoning_budget_reset(struct llama_sampler * smpl) {
     ctx->end_matcher.reset();
     ctx->force_pos = 0;
     ctx->end_match = -1;
+    for (auto & sp : ctx->soft_points) {
+        sp.triggered = false;
+        sp.force_pos = 0;
+    }
+    ctx->active_soft          = 0;
+    ctx->intro_force_pos      = 0;
+    ctx->grace_remaining      = ctx->grace_tokens;
+    ctx->hard_pending_prev_nl = false;
 }
 
 static struct llama_sampler * common_reasoning_budget_init_state(
-        const struct llama_vocab * vocab, const std::vector<llama_tokens> & start_seqs,
-        const std::vector<llama_tokens> & end_seqs, const llama_tokens & forced_tokens,
-        int32_t budget, common_reasoning_budget_state initial_state);
+    const struct llama_vocab *                              vocab,
+    const std::vector<llama_tokens> &                       start_seqs,
+    const std::vector<llama_tokens> &                       end_seqs,
+    const llama_tokens &                                    forced_tokens,
+    const std::vector<common_reasoning_budget_soft_point> & soft_points,
+    const llama_tokens &                                    intro_forced_tokens,
+    int32_t                                                 budget,
+    int32_t                                                 grace_tokens,
+    common_reasoning_budget_state                           initial_state);
 
 static struct llama_sampler * common_reasoning_budget_clone(const struct llama_sampler * smpl);
 
@@ -231,41 +387,63 @@ static struct llama_sampler * common_reasoning_budget_clone(const struct llama_s
 }
 
 static struct llama_sampler * common_reasoning_budget_init_state(
-        const struct llama_vocab        * vocab,
-        const std::vector<llama_tokens> & start_seqs,
-        const std::vector<llama_tokens> & end_seqs,
-        const llama_tokens              & forced_tokens,
-        int32_t                           budget,
-        common_reasoning_budget_state     initial_state) {
-    // promote COUNTING with budget <= 0 to FORCING
+    const struct llama_vocab *                              vocab,
+    const std::vector<llama_tokens> &                       start_seqs,
+    const std::vector<llama_tokens> &                       end_seqs,
+    const llama_tokens &                                    forced_tokens,
+    const std::vector<common_reasoning_budget_soft_point> & soft_points,
+    const llama_tokens &                                    intro_forced_tokens,
+    int32_t                                                 budget,
+    int32_t                                                 grace_tokens,
+    common_reasoning_budget_state                           initial_state) {
     if (initial_state == REASONING_BUDGET_COUNTING && budget <= 0) {
         initial_state = REASONING_BUDGET_FORCING;
     }
 
+    std::vector<common_reasoning_budget_ctx::soft_point_state> soft_pts;
+    for (const auto & p : soft_points) {
+        if (!p.tokens.empty() && p.threshold >= 0) {
+            soft_pts.push_back({ p.threshold, p.tokens, false, 0 });
+        }
+    }
+    std::sort(soft_pts.begin(), soft_pts.end(),
+              [](const common_reasoning_budget_ctx::soft_point_state & a,
+                 const common_reasoning_budget_ctx::soft_point_state & b) { return a.threshold > b.threshold; });
+
     return llama_sampler_init(
         /* .iface = */ &common_reasoning_budget_i,
-        /* .ctx   = */ new common_reasoning_budget_ctx {
-            /* .vocab         = */ vocab,
-            /* .start_matcher = */ token_matcher(start_seqs),
-            /* .end_matcher   = */ token_matcher(end_seqs),
-            /* .forced_tokens = */ forced_tokens,
-            /* .budget        = */ budget,
-            /* .remaining     = */ budget,
-            /* .state         = */ initial_state,
-            /* .force_pos     = */ 0,
-            /* .end_match     = */ -1,
-        }
-    );
+        /* .ctx   = */ new common_reasoning_budget_ctx{
+            /* .vocab                = */ vocab,
+            /* .start_matcher        = */ token_matcher(start_seqs),
+            /* .end_matcher          = */ token_matcher(end_seqs),
+            /* .forced_tokens        = */ forced_tokens,
+            /* .budget               = */ budget,
+            /* .remaining            = */ budget,
+            /* .state                = */ initial_state,
+            /* .force_pos            = */ 0,
+            /* .end_match            = */ -1,
+            /* .soft_points          = */ std::move(soft_pts),
+            /* .active_soft          = */ 0,
+            /* .intro_forced_tokens  = */ intro_forced_tokens,
+            /* .intro_force_pos      = */ 0,
+            /* .grace_tokens         = */ grace_tokens,
+            /* .grace_remaining      = */ grace_tokens,
+            /* .hard_pending_prev_nl = */ false,
+        });
 }
 
 struct llama_sampler * common_reasoning_budget_init(
-        const struct llama_vocab        * vocab,
-        const std::vector<llama_tokens> & start_seqs,
-        const std::vector<llama_tokens> & end_seqs,
-        const llama_tokens              & forced_tokens,
-        int32_t                           budget,
-        common_reasoning_budget_state     initial_state) {
-    return common_reasoning_budget_init_state(vocab, start_seqs, end_seqs, forced_tokens, budget, initial_state);
+        const struct llama_vocab *                              vocab,
+        const std::vector<llama_tokens> &                       start_seqs,
+        const std::vector<llama_tokens> &                       end_seqs,
+        const llama_tokens &                                    forced_tokens,
+        const std::vector<common_reasoning_budget_soft_point> & soft_points,
+        const llama_tokens &                                    intro_forced_tokens,
+        int32_t                                                 budget,
+        int32_t                                                 grace_tokens,
+        common_reasoning_budget_state                           initial_state) {
+    return common_reasoning_budget_init_state(vocab, start_seqs, end_seqs, forced_tokens, soft_points,
+                                              intro_forced_tokens, budget, grace_tokens, initial_state);
 }
 
 common_reasoning_budget_state common_reasoning_budget_get_state(const struct llama_sampler * smpl) {
@@ -295,9 +473,9 @@ bool common_reasoning_budget_force(struct llama_sampler * smpl) {
 
     auto * ctx = (common_reasoning_budget_ctx *) smpl->ctx;
 
-    // only a sampler that is actively counting down the budget may be forced;
-    // any other state (idle, already forcing/waiting, or done) is left untouched
-    if (ctx->state != REASONING_BUDGET_COUNTING) {
+    if (ctx->state != REASONING_BUDGET_COUNTING && ctx->state != REASONING_BUDGET_INTRO_FORCING &&
+        ctx->state != REASONING_BUDGET_SOFT_PENDING && ctx->state != REASONING_BUDGET_SOFT_FORCING &&
+        ctx->state != REASONING_BUDGET_HARD_PENDING) {
         return false;
     }
 

--- a/common/reasoning-budget.h
+++ b/common/reasoning-budget.h
@@ -8,38 +8,55 @@
 #include <vector>
 
 enum common_reasoning_budget_state {
-    REASONING_BUDGET_IDLE,         // waiting for start sequence
-    REASONING_BUDGET_COUNTING,     // counting down tokens
-    REASONING_BUDGET_FORCING,      // forcing budget message + end sequence
-    REASONING_BUDGET_WAITING_UTF8, // budget exhausted, waiting for UTF-8 completion
-    REASONING_BUDGET_DONE,         // passthrough forever
+    REASONING_BUDGET_IDLE,           // Waiting for start sequence.
+    REASONING_BUDGET_INTRO_FORCING,  // Forcing the intro message.
+    REASONING_BUDGET_COUNTING,       // Counting down tokens.
+    REASONING_BUDGET_SOFT_PENDING,   // Waiting for a soft-warning newline boundary.
+    REASONING_BUDGET_SOFT_FORCING,   // Forcing the soft warning message.
+    REASONING_BUDGET_HARD_PENDING,   // Waiting for a hard-cutoff paragraph boundary.
+    REASONING_BUDGET_FORCING,        // Forcing budget message and end sequence.
+    REASONING_BUDGET_WAITING_UTF8,   // Waiting for UTF-8 completion before forcing.
+    REASONING_BUDGET_DONE,           // Passthrough forever.
 };
 
-// Creates a reasoning budget sampler that limits token generation inside a
-// reasoning block (e.g. between <think> and </think>).
+struct common_reasoning_budget_soft_point {
+    int32_t      threshold;  // Fire when remaining <= threshold.
+    llama_tokens tokens;     // Message forced at this point. Empty disables it.
+};
+
+// Creates a sampler that limits generation inside a reasoning block.
+// Intro, soft, and forced tokens do not count against the budget.
 //
-// State machine: IDLE -> COUNTING -> WAITING_UTF8 -> FORCING -> DONE
-//   IDLE:         passthrough, watching for a start sequence
-//   COUNTING:     counting down remaining tokens, watching for a natural end sequence
-//   WAITING_UTF8: budget exhausted, allowing tokens to complete a UTF-8 sequence
-//   FORCING:      forces forced_tokens token-by-token (all other logits -> -inf)
-//   DONE:         passthrough forever
+// State machine:
+// IDLE -> INTRO_FORCING -> COUNTING -> SOFT_PENDING -> SOFT_FORCING ->
+// COUNTING -> HARD_PENDING -> WAITING_UTF8 -> FORCING -> DONE
+//
+// A soft point fires once at the next newline after its threshold is crossed.
+// The hard cutoff takes priority when the budget is exhausted.
+//
+// A positive grace_tokens value waits for a paragraph boundary after exhaustion.
+// It forces after at most grace_tokens more tokens.
 //
 // Parameters:
-//   vocab          - vocabulary (used for UTF-8 boundary detection; can be nullptr)
-//   start_seqs     - token sequences, any of which activates counting
-//   end_seqs       - token sequences, any of which naturally deactivates
-//   forced_tokens  - token sequence forced when budget expires
-//   budget         - max tokens allowed in the reasoning block
-//   initial_state  - initial state
-//
+//   vocab               - vocabulary for UTF-8 and paragraph boundary detection
+//   start_seqs          - sequences that activate counting
+//   end_seqs            - sequences that naturally deactivate
+//   forced_tokens       - sequence forced when the budget expires
+//   soft_points         - soft warning points
+//   intro_forced_tokens - sequence forced when the block starts
+//   budget              - max generated tokens in the reasoning block
+//   grace_tokens        - max tokens to wait for a paragraph boundary
+//   initial_state       - initial state
 struct llama_sampler * common_reasoning_budget_init(
-        const struct llama_vocab        * vocab,
-        const std::vector<llama_tokens> & start_seqs,
-        const std::vector<llama_tokens> & end_seqs,
-        const llama_tokens              & forced_tokens,
-        int32_t                           budget,
-        common_reasoning_budget_state     initial_state = REASONING_BUDGET_IDLE);
+    const struct llama_vocab *                              vocab,
+    const std::vector<llama_tokens> &                       start_seqs,
+    const std::vector<llama_tokens> &                       end_seqs,
+    const llama_tokens &                                    forced_tokens,
+    const std::vector<common_reasoning_budget_soft_point> & soft_points,
+    const llama_tokens &                                    intro_forced_tokens,
+    int32_t                                                 budget,
+    int32_t                                                 grace_tokens  = 0,
+    common_reasoning_budget_state                           initial_state = REASONING_BUDGET_IDLE);
 
 common_reasoning_budget_state common_reasoning_budget_get_state(const struct llama_sampler * smpl);
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -307,18 +307,39 @@ struct common_sampler * common_sampler_init(
         }
     }
 
-    // reasoning budget sampler (skip when budget is unlimited unless a lazy grammar is active, which needs rbudget for thinking-block suppression)
-    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && (params.grammar_lazy || params.reasoning_budget_tokens >= 0 || params.reasoning_control)) {
-        rbudget = common_reasoning_budget_init(
-            vocab,
-            {params.reasoning_budget_start},
-            params.reasoning_budget_end,
-            params.reasoning_budget_forced,
-            params.reasoning_budget_tokens < 0 ? INT_MAX : params.reasoning_budget_tokens);
+    // Grammar lazy mode needs the sampler to suppress grammar in a reasoning block.
+    // The master switch gates budget forcing and runtime reasoning control only.
+    const bool reasoning_budget_active =
+        params.reasoning_budget_enabled && (params.reasoning_budget_tokens >= 0 || params.reasoning_control);
+    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() &&
+        (params.grammar_lazy || reasoning_budget_active)) {
+        const int32_t budget_tokens = params.reasoning_budget_tokens < 0 ? INT_MAX : params.reasoning_budget_tokens;
+
+        std::vector<common_reasoning_budget_soft_point> soft_points;
+        auto add_soft_point = [&](float ratio, const llama_tokens & tokens) {
+            if (ratio > 0.0f && !tokens.empty() && budget_tokens != INT_MAX) {
+                const float r = std::min(ratio, 1.0f);
+                soft_points.push_back({ std::max(0, budget_tokens - (int32_t) std::ceil(budget_tokens * r)), tokens });
+            }
+        };
+        add_soft_point(params.reasoning_budget_soft_ratio, params.reasoning_budget_soft_forced);
+        add_soft_point(params.reasoning_budget_soft2_ratio, params.reasoning_budget_soft2_forced);
+
+        const llama_tokens intro_tokens =
+            reasoning_budget_active ? params.reasoning_budget_intro_forced : llama_tokens();
+        rbudget = common_reasoning_budget_init(vocab, { params.reasoning_budget_start }, params.reasoning_budget_end,
+                                               params.reasoning_budget_forced, soft_points, intro_tokens, budget_tokens,
+                                               params.reasoning_budget_grace_tokens);
 
         for (const auto & token : prefill_tokens) {
             llama_sampler_accept(rbudget, token);
             LOG_DBG("%s: reasoning-budget accepted prefill token (%d)\n", __func__, token);
+
+            const auto state = common_reasoning_budget_get_state(rbudget);
+            if (state == REASONING_BUDGET_INTRO_FORCING || state == REASONING_BUDGET_SOFT_FORCING ||
+                state == REASONING_BUDGET_FORCING) {
+                break;
+            }
         }
     }
 

--- a/docs/speculative.md
+++ b/docs/speculative.md
@@ -428,7 +428,7 @@ statistics draft: #calls = 10, #gen drafts = 10, #acc drafts = 10, #gen tokens =
 
 ```
 draft acceptance rate = 0.70312 (   90 accepted /   128 generated)
-statistics ngram_mod: #calls = 810, #gen drafts = 15, #acc drafts = 15, #gen tokens = 960, #acc tokens = 730, dur(b,g,a) = 0.149, 0.347, 0.005 ms
+statistics ngram-mod: #calls = 810, #gen drafts = 15, #acc drafts = 15, #gen tokens = 960, #acc tokens = 730, dur(b,g,a) = 0.149, 0.347, 0.005 ms
 ```
 
 ```

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -7058,6 +7058,55 @@ static void test_reasoning_budget_message_per_request() {
     }
 }
 
+static void test_reasoning_budget_enabled_per_request() {
+    LOG_DBG("%s\n", __func__);
+    auto tmpls = read_templates("models/templates/Qwen-Qwen3-0.6B.jinja");
+
+    server_chat_params opt;
+    opt.tmpls            = std::move(tmpls);
+    opt.use_jinja        = true;
+    opt.enable_thinking  = true;
+    opt.reasoning_budget = -1;
+    opt.reasoning_format = COMMON_REASONING_FORMAT_NONE;
+
+    {
+        json body = {
+            {"messages", json::array({json{{"role", "user"}, {"content", "hello"}}})},
+            {"reasoning_budget_enabled", true},
+        };
+        std::vector<raw_buffer> out_files;
+        auto llama_params = oaicompat_chat_params_parse(body, opt, out_files);
+        if (!llama_params.contains("reasoning_budget_enabled") ||
+            !llama_params["reasoning_budget_enabled"].get<bool>()) {
+            throw std::runtime_error("reasoning_budget_enabled=true not forwarded to llama_params");
+        }
+    }
+
+    {
+        json body = {
+            {"messages", json::array({json{{"role", "user"}, {"content", "hello"}}})},
+            {"reasoning_budget_enabled", false},
+        };
+        std::vector<raw_buffer> out_files;
+        auto llama_params = oaicompat_chat_params_parse(body, opt, out_files);
+        if (!llama_params.contains("reasoning_budget_enabled") ||
+            llama_params["reasoning_budget_enabled"].get<bool>()) {
+            throw std::runtime_error("reasoning_budget_enabled=false not forwarded to llama_params");
+        }
+    }
+
+    {
+        json body = {
+            {"messages", json::array({json{{"role", "user"}, {"content", "hello"}}})},
+        };
+        std::vector<raw_buffer> out_files;
+        auto llama_params = oaicompat_chat_params_parse(body, opt, out_files);
+        if (llama_params.contains("reasoning_budget_enabled")) {
+            throw std::runtime_error("reasoning_budget_enabled must not be set in llama_params when omitted from the request body");
+        }
+    }
+}
+
 static void test_reasoning_effort_caps() {
     LOG_DBG("%s\n", __func__);
 
@@ -7238,6 +7287,7 @@ int main(int argc, char ** argv) {
         test_reasoning_effort_caps();
         test_reasoning_budget_tokens_per_request();
         test_reasoning_budget_message_per_request();
+        test_reasoning_budget_enabled_per_request();
         test_template_output_peg_parsers(detailed_debug);
         std::cout << "\n[chat] All tests passed!" << '\n';
     }

--- a/tests/test-reasoning-budget.cpp
+++ b/tests/test-reasoning-budget.cpp
@@ -43,11 +43,14 @@ static void test_reasoning_budget(
     // For this test, we use nullptr as vocab since we're testing state transitions
     // The UTF-8 boundary check will treat all tokens as complete (safe fallback)
     auto * sampler = common_reasoning_budget_init(
-        nullptr,  // vocab - not used for basic state machine tests
+        nullptr,
         start_seqs,
         end_seqs,
         forced_tokens,
+        {},
+        {},
         budget,
+        0,
         initial_state
     );
 
@@ -156,7 +159,7 @@ static void test_reasoning_budget_clone_mid_counting() {
     const std::vector<llama_token> end = {101};
     const std::vector<llama_token> forced = {102, 101};
 
-    auto * sampler = common_reasoning_budget_init(nullptr, {start}, {end}, forced, 2, REASONING_BUDGET_IDLE);
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 2, 0, REASONING_BUDGET_IDLE);
 
     llama_sampler_accept(sampler, 100); // COUNTING, remaining=2
     llama_sampler_accept(sampler, 50);  // COUNTING, remaining=1
@@ -175,7 +178,7 @@ static void test_reasoning_budget_clone_mid_forcing() {
     const std::vector<llama_token> end = {101};
     const std::vector<llama_token> forced = {102, 101};
 
-    auto * sampler = common_reasoning_budget_init(nullptr, {start}, {end}, forced, 0, REASONING_BUDGET_FORCING);
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 0, 0, REASONING_BUDGET_FORCING);
 
     GGML_ASSERT(get_forced_token(sampler, 102) == 102);
     llama_sampler_accept(sampler, 102); // advance to the second forced token
@@ -195,7 +198,7 @@ static void test_reasoning_budget_force_manual() {
 
     // if COUNTING, force() succeeds and begins forcing the end sequence from the start
     {
-        auto * sampler = common_reasoning_budget_init(nullptr, {start}, {end}, forced, 5, REASONING_BUDGET_IDLE);
+        auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 5, 0, REASONING_BUDGET_IDLE);
 
         llama_sampler_accept(sampler, 100); // COUNTING, remaining=5
         llama_sampler_accept(sampler, 50);  // COUNTING, remaining=4
@@ -216,7 +219,7 @@ static void test_reasoning_budget_force_manual() {
 
     // if IDLE, force() is a no-op
     {
-        auto * sampler = common_reasoning_budget_init(nullptr, {start}, {end}, forced, 5, REASONING_BUDGET_IDLE);
+        auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 5, 0, REASONING_BUDGET_IDLE);
 
         GGML_ASSERT(!common_reasoning_budget_force(sampler) && "force() must not transition from IDLE");
         GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_IDLE);
@@ -226,7 +229,7 @@ static void test_reasoning_budget_force_manual() {
 
     // if DONE, force() is a no-op
     {
-        auto * sampler = common_reasoning_budget_init(nullptr, {start}, {end}, forced, 5, REASONING_BUDGET_IDLE);
+        auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 5, 0, REASONING_BUDGET_IDLE);
 
         llama_sampler_accept(sampler, 100); // COUNTING
         llama_sampler_accept(sampler, 101); // natural end -> DONE
@@ -240,7 +243,7 @@ static void test_reasoning_budget_force_manual() {
 
     // if FORCING, force() is a no-op and must not rewind the force position
     {
-        auto * sampler = common_reasoning_budget_init(nullptr, {start}, {end}, forced, 0, REASONING_BUDGET_FORCING);
+        auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 0, 0, REASONING_BUDGET_FORCING);
 
         GGML_ASSERT(get_forced_token(sampler, 102) == 102);
         llama_sampler_accept(sampler, 102); // advance to the second forced token (force_pos=1)
@@ -258,13 +261,279 @@ static void test_reasoning_budget_force_manual() {
     fprintf(stderr, "  Test 'manual force transition' passed\n");
 }
 
+static void test_reasoning_budget_soft_warning_skipped_before_hard_cutoff() {
+    const std::vector<llama_token> start       = { 100 };
+    const std::vector<llama_token> end         = { 101 };
+    const std::vector<llama_token> forced      = { 102, 101 };
+    const std::vector<llama_token> soft_forced = { 200, 201 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, { { 5, soft_forced } }, {}, 10, 0, REASONING_BUDGET_IDLE);
+
+    llama_sampler_accept(sampler, 100);
+    for (llama_token t : { 50, 51, 52, 53 }) {
+        llama_sampler_accept(sampler, t);
+    }
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_COUNTING);
+
+    llama_sampler_accept(sampler, 54);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_SOFT_PENDING);
+
+    for (llama_token t : { 55, 56, 57, 58 }) {
+        llama_sampler_accept(sampler, t);
+        GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_SOFT_PENDING);
+    }
+    llama_sampler_accept(sampler, 59);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+    GGML_ASSERT(get_forced_token(sampler, 202) == 102);
+
+    llama_sampler_accept(sampler, 102);
+    GGML_ASSERT(get_forced_token(sampler, 202) == 101);
+    llama_sampler_accept(sampler, 101);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_DONE);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_soft_forcing_resumes_counting() {
+    const std::vector<llama_token> start       = { 100 };
+    const std::vector<llama_token> end         = { 101 };
+    const std::vector<llama_token> forced      = { 102, 101 };
+    const std::vector<llama_token> soft_forced = { 200, 201 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, { { 2, soft_forced } }, {}, 5, 0, REASONING_BUDGET_SOFT_FORCING);
+
+    GGML_ASSERT(get_forced_token(sampler, 201) == 200);
+    llama_sampler_accept(sampler, 200);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_SOFT_FORCING);
+
+    GGML_ASSERT(get_forced_token(sampler, 201) == 201);
+    llama_sampler_accept(sampler, 201);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_COUNTING);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_force_manual_from_soft_states() {
+    const std::vector<llama_token> start       = { 100 };
+    const std::vector<llama_token> end         = { 101 };
+    const std::vector<llama_token> forced      = { 102, 101 };
+    const std::vector<llama_token> soft_forced = { 200, 201 };
+
+    {
+        auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, { { 5, soft_forced } }, {}, 10, 0, REASONING_BUDGET_IDLE);
+
+        llama_sampler_accept(sampler, 100);
+        for (llama_token t : { 50, 51, 52, 53, 54 }) {
+            llama_sampler_accept(sampler, t);
+        }
+        GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_SOFT_PENDING);
+
+        GGML_ASSERT(common_reasoning_budget_force(sampler));
+        GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+        GGML_ASSERT(get_forced_token(sampler, 202) == 102);
+
+        llama_sampler_free(sampler);
+    }
+
+    {
+        auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, { { 2, soft_forced } }, {}, 5, 0, REASONING_BUDGET_SOFT_FORCING);
+
+        llama_sampler_accept(sampler, 200);
+        GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_SOFT_FORCING);
+
+        GGML_ASSERT(common_reasoning_budget_force(sampler));
+        GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+        GGML_ASSERT(get_forced_token(sampler, 202) == 102);
+
+        llama_sampler_free(sampler);
+    }
+}
+
+static void test_reasoning_budget_intro_forcing_then_counting() {
+    const std::vector<llama_token> start        = { 100 };
+    const std::vector<llama_token> end          = { 101 };
+    const std::vector<llama_token> forced       = { 102, 101 };
+    const std::vector<llama_token> intro_forced = { 300, 301 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, intro_forced, 3, 0, REASONING_BUDGET_IDLE);
+
+    llama_sampler_accept(sampler, 100);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_INTRO_FORCING);
+
+    GGML_ASSERT(get_forced_token(sampler, 301) == 300);
+    llama_sampler_accept(sampler, 300);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_INTRO_FORCING);
+
+    GGML_ASSERT(get_forced_token(sampler, 301) == 301);
+    llama_sampler_accept(sampler, 301);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_COUNTING);
+
+    llama_sampler_accept(sampler, 50);
+    llama_sampler_accept(sampler, 51);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_COUNTING);
+    llama_sampler_accept(sampler, 52);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+    GGML_ASSERT(get_forced_token(sampler, 302) == 102);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_intro_forcing_budget_zero() {
+    const std::vector<llama_token> start        = { 100 };
+    const std::vector<llama_token> end          = { 101 };
+    const std::vector<llama_token> forced       = { 102, 101 };
+    const std::vector<llama_token> intro_forced = { 300, 301 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, intro_forced, 0, 0, REASONING_BUDGET_IDLE);
+
+    llama_sampler_accept(sampler, 100);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_INTRO_FORCING);
+
+    llama_sampler_accept(sampler, 300);
+    llama_sampler_accept(sampler, 301);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+    GGML_ASSERT(get_forced_token(sampler, 302) == 102);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_force_manual_from_intro() {
+    const std::vector<llama_token> start        = { 100 };
+    const std::vector<llama_token> end          = { 101 };
+    const std::vector<llama_token> forced       = { 102, 101 };
+    const std::vector<llama_token> intro_forced = { 300, 301 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, intro_forced, 5, 0, REASONING_BUDGET_INTRO_FORCING);
+
+    llama_sampler_accept(sampler, 300);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_INTRO_FORCING);
+
+    GGML_ASSERT(common_reasoning_budget_force(sampler));
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+    GGML_ASSERT(get_forced_token(sampler, 302) == 102);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_intro_rearms_on_multiblock() {
+    const std::vector<llama_token> start        = { 100 };
+    const std::vector<llama_token> end          = { 101 };
+    const std::vector<llama_token> forced       = { 102, 101 };
+    const std::vector<llama_token> intro_forced = { 300, 301 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, intro_forced, 5, 0, REASONING_BUDGET_IDLE);
+
+    llama_sampler_accept(sampler, 100);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_INTRO_FORCING);
+    llama_sampler_accept(sampler, 300);
+    llama_sampler_accept(sampler, 301);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_COUNTING);
+    llama_sampler_accept(sampler, 101);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_DONE);
+
+    llama_sampler_accept(sampler, 100);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_INTRO_FORCING);
+    GGML_ASSERT(get_forced_token(sampler, 302) == 300);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_hard_pending_grace_expires() {
+    const std::vector<llama_token> start  = { 100 };
+    const std::vector<llama_token> end    = { 101 };
+    const std::vector<llama_token> forced = { 102, 101 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 2, 3, REASONING_BUDGET_IDLE);
+
+    llama_sampler_accept(sampler, 100);
+    llama_sampler_accept(sampler, 50);
+    llama_sampler_accept(sampler, 51);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_HARD_PENDING);
+
+    llama_sampler_accept(sampler, 52);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_HARD_PENDING);
+    llama_sampler_accept(sampler, 53);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_HARD_PENDING);
+    llama_sampler_accept(sampler, 54);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+    GGML_ASSERT(get_forced_token(sampler, 102) == 102);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_hard_pending_natural_end() {
+    const std::vector<llama_token> start  = { 100 };
+    const std::vector<llama_token> end    = { 101 };
+    const std::vector<llama_token> forced = { 102, 101 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 2, 5, REASONING_BUDGET_IDLE);
+
+    llama_sampler_accept(sampler, 100);
+    llama_sampler_accept(sampler, 50);
+    llama_sampler_accept(sampler, 51);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_HARD_PENDING);
+
+    llama_sampler_accept(sampler, 101);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_DONE);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_force_manual_from_hard_pending() {
+    const std::vector<llama_token> start  = { 100 };
+    const std::vector<llama_token> end    = { 101 };
+    const std::vector<llama_token> forced = { 102, 101 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, {}, {}, 2, 10, REASONING_BUDGET_IDLE);
+
+    llama_sampler_accept(sampler, 100);
+    llama_sampler_accept(sampler, 50);
+    llama_sampler_accept(sampler, 51);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_HARD_PENDING);
+
+    GGML_ASSERT(common_reasoning_budget_force(sampler));
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+    GGML_ASSERT(get_forced_token(sampler, 102) == 102);
+
+    llama_sampler_free(sampler);
+}
+
+static void test_reasoning_budget_soft_pending_exhaustion_uses_grace() {
+    const std::vector<llama_token> start       = { 100 };
+    const std::vector<llama_token> end         = { 101 };
+    const std::vector<llama_token> forced      = { 102, 101 };
+    const std::vector<llama_token> soft_forced = { 200, 201 };
+
+    auto * sampler = common_reasoning_budget_init(nullptr, { start }, { end }, forced, { { 5, soft_forced } }, {}, 10, 2, REASONING_BUDGET_IDLE);
+
+    llama_sampler_accept(sampler, 100);
+    for (llama_token t : { 50, 51, 52, 53, 54 }) {
+        llama_sampler_accept(sampler, t);
+    }
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_SOFT_PENDING);
+
+    for (llama_token t : { 55, 56, 57, 58 }) {
+        llama_sampler_accept(sampler, t);
+    }
+    llama_sampler_accept(sampler, 59);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_HARD_PENDING);
+
+    llama_sampler_accept(sampler, 60);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_HARD_PENDING);
+    llama_sampler_accept(sampler, 61);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_FORCING);
+    GGML_ASSERT(get_forced_token(sampler, 202) == 102);
+
+    llama_sampler_free(sampler);
+}
+
 static void test_reasoning_budget_end_match() {
     const std::vector<llama_tokens> start = {{100}};
     const std::vector<llama_tokens> end   = {{101}, {103, 104}};
 
     // natural end records the sequence that matched; re-arming clears it
     {
-        auto * sampler = common_reasoning_budget_init(nullptr, start, end, {102, 101}, 5, REASONING_BUDGET_IDLE);
+        auto * sampler = common_reasoning_budget_init(nullptr, start, end, { 102, 101 }, {}, {}, 5, 0, REASONING_BUDGET_IDLE);
 
         GGML_ASSERT(common_reasoning_budget_get_end_match(sampler) == nullptr);
 
@@ -287,7 +556,7 @@ static void test_reasoning_budget_end_match() {
     {
         const std::vector<llama_tokens> end_overlap = {{104}, {103, 104}};
 
-        auto * sampler = common_reasoning_budget_init(nullptr, start, end_overlap, {102, 104}, 5, REASONING_BUDGET_IDLE);
+        auto * sampler = common_reasoning_budget_init(nullptr, start, end_overlap, { 102, 104 }, {}, {}, 5, 0, REASONING_BUDGET_IDLE);
 
         llama_sampler_accept(sampler, 100); // COUNTING
         llama_sampler_accept(sampler, 103);
@@ -302,7 +571,7 @@ static void test_reasoning_budget_end_match() {
 
     // forcing records the end sequence terminating forced_tokens
     {
-        auto * sampler = common_reasoning_budget_init(nullptr, start, end, {102, 103, 104}, 0, REASONING_BUDGET_FORCING);
+        auto * sampler = common_reasoning_budget_init(nullptr, start, end, { 102, 103, 104 }, {}, {}, 0, 0, REASONING_BUDGET_FORCING);
 
         llama_sampler_accept(sampler, 102);
         llama_sampler_accept(sampler, 103);
@@ -318,7 +587,7 @@ static void test_reasoning_budget_end_match() {
 
     // forced_tokens not ending with a known end sequence records nothing
     {
-        auto * sampler = common_reasoning_budget_init(nullptr, start, end, {102}, 0, REASONING_BUDGET_FORCING);
+        auto * sampler = common_reasoning_budget_init(nullptr, start, end, { 102 }, {}, {}, 0, 0, REASONING_BUDGET_FORCING);
 
         llama_sampler_accept(sampler, 102); // forced sequence complete, DONE
         GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_DONE);
@@ -493,9 +762,20 @@ int main(void) {
     test_reasoning_budget_clone_mid_counting();
     test_reasoning_budget_clone_mid_forcing();
     test_reasoning_budget_force_manual();
+    test_reasoning_budget_soft_warning_skipped_before_hard_cutoff();
+    test_reasoning_budget_soft_forcing_resumes_counting();
+    test_reasoning_budget_force_manual_from_soft_states();
+    test_reasoning_budget_intro_forcing_then_counting();
+    test_reasoning_budget_intro_forcing_budget_zero();
+    test_reasoning_budget_force_manual_from_intro();
+    test_reasoning_budget_intro_rearms_on_multiblock();
+    test_reasoning_budget_hard_pending_grace_expires();
+    test_reasoning_budget_hard_pending_natural_end();
+    test_reasoning_budget_force_manual_from_hard_pending();
+    test_reasoning_budget_soft_pending_exhaustion_uses_grace();
     test_reasoning_budget_end_match();
 
-    printf("OK (12 tests passed)\n");
+    printf("OK (23 tests passed)\n");
 
     printf("Testing UTF-8 boundary detection... ");
     test_utf8_boundary_detection();

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -233,8 +233,16 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--reasoning-format FORMAT` | controls whether thought tags are allowed and/or extracted from the response, and in which format they're returned; one of:<br/>- none: leaves thoughts unparsed in `message.content`<br/>- deepseek: puts thoughts in `message.reasoning_content`<br/>- deepseek-legacy: keeps `<think>` tags in `message.content` while also populating `message.reasoning_content`<br/>(default: auto)<br/>(env: LLAMA_ARG_THINK) |
 | `-rea, --reasoning [on\|off\|auto]` | Use reasoning/thinking in the chat ('on', 'off', or 'auto', default: 'auto' (detect from template))<br/>(env: LLAMA_ARG_REASONING) |
 | `--reasoning-effort LEVEL` | reasoning effort level given to the chat template: 'default' to keep the template default,<br/>or a level such as 'minimal', 'low', 'medium', 'high', 'xhigh' or 'max' (default: default)<br/>(env: LLAMA_ARG_REASONING_EFFORT) |
+| `--reasoning-budget-enable, --no-reasoning-budget-enable` | master switch for hard cutoff, soft warnings, intro message, grace period, and runtime reasoning control (default: disabled)<br/>(env: LLAMA_ARG_THINK_BUDGET_ENABLE) |
 | `--reasoning-budget N` | token budget for thinking: -1 for unrestricted, 0 for immediate end, N>0 for token budget (default: -1)<br/>(env: LLAMA_ARG_THINK_BUDGET) |
-| `--reasoning-budget-message MESSAGE` | message injected before the end-of-thinking tag when reasoning budget is exhausted (default: none)<br/>(env: LLAMA_ARG_THINK_BUDGET_MESSAGE) |
+| `--reasoning-budget-message MESSAGE` | message forced when the reasoning budget is exhausted; include the model's closing tag when required by the template (default: none)<br/>(env: LLAMA_ARG_THINK_BUDGET_MESSAGE) |
+| `--reasoning-budget-soft-ratio N` | fraction of the budget consumed before the first soft warning; <= 0 disables (default: -1) |
+| `--reasoning-budget-soft-message MESSAGE` | first soft-warning message, injected at a newline boundary |
+| `--reasoning-budget-soft2-ratio N` | fraction of the budget consumed before the second soft warning; <= 0 disables (default: -1) |
+| `--reasoning-budget-soft2-message MESSAGE` | second soft-warning message, injected at a newline boundary |
+| `--reasoning-budget-intro-mode MODE` | `every` forces the intro for every reasoning block; `once` suppresses it when already present in the prompt (default: every) |
+| `--reasoning-budget-intro-message MESSAGE` | message forced at the start of reasoning; `{budget}` is replaced by the configured budget |
+| `--reasoning-budget-grace-tokens N` | tokens to allow after budget exhaustion while waiting for a paragraph break (default: 0) |
 | `--reasoning-preserve, --no-reasoning-preserve` | preserve reasoning trace in the full history, not just the last assistant message (default: template default)<br/>compatible with certain templates having 'supports_preserve_reasoning' capability<br/>example: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking<br/>(env: LLAMA_ARG_REASONING_PRESERVE) |
 | `--chat-template JINJA_TEMPLATE` | set custom jinja chat template (default: template taken from model's metadata)<br/>if suffix/prefix are specified, template will be disabled<br/>only commonly used templates are accepted (unless --jinja is set before this flag):<br/>list of built-in templates:<br/>bailing, bailing-think, bailing2, chatglm3, chatglm4, chatml, command-r, deepseek, deepseek-ocr, deepseek2, deepseek3, exaone-moe, exaone3, exaone4, falcon3, gemma, gigachat, glmedge, gpt-oss, granite, granite-4.0, granite-4.1, grok-2, hunyuan-dense, hunyuan-moe, hunyuan-vl, kimi-k2, llama2, llama2-sys, llama2-sys-bos, llama2-sys-strip, llama3, llama4, megrez, minicpm, mistral-v1, mistral-v3, mistral-v3-tekken, mistral-v7, mistral-v7-tekken, monarch, openchat, orion, pangu-embedded, phi3, phi4, rwkv-world, seed_oss, smolvlm, solar-open, vicuna, vicuna-orca, yandex, zephyr<br/>(env: LLAMA_ARG_CHAT_TEMPLATE) |
 | `--chat-template-file JINJA_TEMPLATE_FILE` | set custom jinja chat template file (default: template taken from model's metadata)<br/>if suffix/prefix are specified, template will be disabled<br/>only commonly used templates are accepted (unless --jinja is set before this flag):<br/>list of built-in templates:<br/>bailing, bailing-think, bailing2, chatglm3, chatglm4, chatml, command-r, deepseek, deepseek-ocr, deepseek2, deepseek3, exaone-moe, exaone3, exaone4, falcon3, gemma, gigachat, glmedge, gpt-oss, granite, granite-4.0, granite-4.1, grok-2, hunyuan-dense, hunyuan-moe, hunyuan-vl, kimi-k2, llama2, llama2-sys, llama2-sys-bos, llama2-sys-strip, llama3, llama4, megrez, minicpm, mistral-v1, mistral-v3, mistral-v3-tekken, mistral-v7, mistral-v7-tekken, monarch, openchat, orion, pangu-embedded, phi3, phi4, rwkv-world, seed_oss, smolvlm, solar-open, vicuna, vicuna-orca, yandex, zephyr<br/>(env: LLAMA_ARG_CHAT_TEMPLATE_FILE) |
@@ -1324,6 +1332,8 @@ The `response_format` parameter supports both plain JSON output (e.g. `{"type": 
 
 `reasoning_control`: Arms realtime reasoning control for this completion so it can be ended early via `/v1/chat/completions/control`. Defaults to `false`.
 
+`reasoning_budget_enabled`: Explicit master switch for reasoning budget, soft-warning, intro, grace, and runtime reasoning control fields. Omit it to keep the server or CLI default.
+
 `generation_prompt`: The generation prompt that was prefilled in by the template. Prepended to model output before parsing.
 
 `parse_tool_calls`: Whether to parse the generated tool call.
@@ -1432,7 +1442,11 @@ The response also includes a standard `usage` object:
         "total_tokens": 92,
         "prompt_tokens_details": {
             "cached_tokens": 0
-        }
+        },
+        "completion_tokens_details": {
+            "reasoning_tokens": 12
+        },
+        "reasoning": 12
     }
 }
 ```
@@ -1443,6 +1457,10 @@ The server supports parsing and returning reasoning via the `reasoning_content` 
 
 Reasoning input (preserve reasoning in history) is also supported by some specific templates. For more details, please refer to [PR#18994](https://github.com/ggml-org/llama.cpp/pull/18994).
 
+Reasoning budget controls can force a hard cutoff, insert soft warnings, insert an intro message, and wait for a paragraph break after budget exhaustion. Set `reasoning_budget_enabled` in a request to override the server or CLI default.
+
+Chat Completions usage reports reasoning tokens in `usage.reasoning` and `usage.completion_tokens_details.reasoning_tokens`. Responses usage reports them in `usage.reasoning` and `usage.output_tokens_details.reasoning_tokens`.
+
 ### POST `/v1/chat/completions/control`: Control a running chat completion in real time
 
 Acts on an in-flight completion identified by its `id` (the `id` field streamed back by `/v1/chat/completions`). The request is processed in parallel with the SSE stream, so the client sends it while still reading tokens.
@@ -1451,7 +1469,7 @@ Acts on an in-flight completion identified by its `id` (the `id` field streamed 
 
 `id`: (Required) The chat completion id to act on. A completion that has already finished matches nothing and the call is a no-op.
 
-`action`: (Required) The control action to perform. Currently the only supported value is `reasoning_end`, which forces the end of the current reasoning block so the model moves on to the final answer. Requires `reasoning_control: true` on the original completion request.
+`action`: (Required) The control action to perform. Currently the only supported value is `reasoning_end`, which forces the end of the current reasoning block so the model moves on to the final answer. Requires the reasoning budget master switch and `reasoning_control: true` on the original completion request.
 
 `model`: (Required in router mode) The model name, used to route the request to the right instance. Ignored in single model mode.
 

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1368,12 +1368,42 @@ json oaicompat_chat_params_parse(
             reasoning_budget = opt.reasoning_budget;
         }
 
+        const bool reasoning_control = json_value(body, "reasoning_control", false);
+        if (body.contains("reasoning_budget_enabled")) {
+            llama_params["reasoning_budget_enabled"] = body.at("reasoning_budget_enabled");
+        }
+
         if (!chat_params.thinking_end_tags.empty()) {
             llama_params["reasoning_budget_tokens"] = reasoning_budget;
             llama_params["reasoning_budget_start_tag"] = chat_params.thinking_start_tag;
             llama_params["reasoning_budget_end_tags"] = chat_params.thinking_end_tags;
-            llama_params["reasoning_budget_message"] = json_value(body, "reasoning_budget_message", opt.reasoning_budget_message);
-            llama_params["reasoning_control"] = json_value(body, "reasoning_control", false);
+            llama_params["reasoning_control"] = reasoning_control;
+
+            const bool has_per_request_reasoning =
+                reasoning_budget >= 0 || reasoning_control || body.contains("reasoning_budget_message") ||
+                body.contains("reasoning_budget_soft_ratio") || body.contains("reasoning_budget_soft_message") ||
+                body.contains("reasoning_budget_soft2_ratio") || body.contains("reasoning_budget_soft2_message") ||
+                body.contains("reasoning_budget_intro_message") || body.contains("reasoning_budget_intro_mode") ||
+                body.contains("reasoning_budget_grace_tokens");
+
+            if (has_per_request_reasoning) {
+                llama_params["reasoning_budget_message"] =
+                    json_value(body, "reasoning_budget_message", opt.reasoning_budget_message);
+                llama_params["reasoning_budget_soft_ratio"] =
+                    json_value(body, "reasoning_budget_soft_ratio", opt.reasoning_budget_soft_ratio);
+                llama_params["reasoning_budget_soft_message"] =
+                    json_value(body, "reasoning_budget_soft_message", opt.reasoning_budget_soft_message);
+                llama_params["reasoning_budget_soft2_ratio"] =
+                    json_value(body, "reasoning_budget_soft2_ratio", opt.reasoning_budget_soft2_ratio);
+                llama_params["reasoning_budget_soft2_message"] =
+                    json_value(body, "reasoning_budget_soft2_message", opt.reasoning_budget_soft2_message);
+                llama_params["reasoning_budget_intro_message"] =
+                    json_value(body, "reasoning_budget_intro_message", opt.reasoning_budget_intro_message);
+                llama_params["reasoning_budget_intro_mode"] =
+                    json_value(body, "reasoning_budget_intro_mode", opt.reasoning_budget_intro_mode);
+                llama_params["reasoning_budget_grace_tokens"] =
+                    json_value(body, "reasoning_budget_grace_tokens", opt.reasoning_budget_grace_tokens);
+            }
         }
     }
 

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -315,6 +315,13 @@ struct server_chat_params {
     bool enable_thinking = true;
     int  reasoning_budget = -1;
     std::string reasoning_budget_message;
+    float       reasoning_budget_soft_ratio = -1.0f;
+    std::string reasoning_budget_soft_message;
+    float       reasoning_budget_soft2_ratio = -1.0f;
+    std::string reasoning_budget_soft2_message;
+    std::string reasoning_budget_intro_message;
+    std::string reasoning_budget_intro_mode = "every";
+    int         reasoning_budget_grace_tokens = 0;
     std::string media_path;
     bool force_pure_content = false;
 };

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1464,6 +1464,13 @@ private:
                 /* enable_thinking       */ enable_thinking,
                 /* reasoning_budget      */ params_base.sampling.reasoning_budget_tokens,
                 /* reasoning_budget_msg  */ params_base.sampling.reasoning_budget_message,
+                /* reasoning_budget_soft_ratio */ params_base.sampling.reasoning_budget_soft_ratio,
+                /* reasoning_budget_soft_msg   */ params_base.sampling.reasoning_budget_soft_message,
+                /* reasoning_budget_soft2_ratio */ params_base.sampling.reasoning_budget_soft2_ratio,
+                /* reasoning_budget_soft2_msg  */ params_base.sampling.reasoning_budget_soft2_message,
+                /* reasoning_budget_intro_msg  */ params_base.sampling.reasoning_budget_intro_message,
+                /* reasoning_budget_intro_mode */ params_base.sampling.reasoning_budget_intro_mode,
+                /* reasoning_budget_grace_toks */ params_base.sampling.reasoning_budget_grace_tokens,
                 /* media_path            */ params_base.media_path,
                 /* force_pure_content    */ params_base.force_pure_content_parser
             };
@@ -1744,6 +1751,26 @@ private:
         }
 
         SLT_DBG(slot, "launching slot : %s\n", safe_json_to_str(slot.to_json()).c_str());
+
+        if (task.params.sampling.reasoning_budget_intro_mode == "once" &&
+            !task.params.sampling.reasoning_budget_intro_forced.empty() &&
+            task.tokens.size() >= task.params.sampling.reasoning_budget_intro_forced.size()) {
+            const auto * vocab_dedupe = llama_model_get_vocab(model_tgt);
+            auto detok = [&](const auto & toks) {
+                std::string text;
+                for (size_t i = 0; i < toks.size(); i++) {
+                    if (toks[i] != LLAMA_TOKEN_NULL) {
+                        text += common_token_to_piece(vocab_dedupe, toks[i], false);
+                    }
+                }
+                return text;
+            };
+            const std::string needle = detok(task.params.sampling.reasoning_budget_intro_forced);
+            if (!needle.empty() && detok(task.tokens).find(needle) != std::string::npos) {
+                task.params.sampling.reasoning_budget_intro_forced.clear();
+                SLT_DBG(slot, "%s", "reasoning-budget intro already present in prompt, suppressed (intro-mode=once)\n");
+            }
+        }
 
         // initialize samplers
         if (task.need_sampling()) {
@@ -2081,6 +2108,7 @@ private:
 
         res->truncated             = slot.truncated;
         res->n_decoded             = slot.stats.n_gen;
+        res->vocab_usage           = llama_model_get_vocab(model_tgt);
         res->n_prompt_tokens       = slot.task->n_tokens();
         res->n_prompt_tokens_cache = slot.stats.n_prompt_cached;
         res->n_tokens_cached       = slot.prompt.n_tokens();

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -377,12 +377,34 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
             }
         }));
 
+    add((new field_bool("reasoning_budget_enabled", params.sampling.reasoning_budget_enabled))
+        ->set_desc("Master switch for the hard/soft/intro/grace reasoning budget control and runtime reasoning control"));
+
     add((new field_bool("reasoning_control", params.sampling.reasoning_control))
         ->set_desc("Create the budget sampler on demand so reasoning can be ended at runtime"));
 
     add((new field_num("reasoning_budget_tokens", params.sampling.reasoning_budget_tokens))
         ->set_hard_limits(-1, INT32_MAX)
         ->set_desc("Number of tokens in the reasoning budget (-1 = disabled)"));
+    add((new field_num("reasoning_budget_soft_ratio", params.sampling.reasoning_budget_soft_ratio))
+        ->set_hard_limits(-1.0f, 1.0f)
+        ->set_desc("Fraction of the reasoning budget consumed at which to inject a soft warning message before the hard cutoff (<= 0 = disabled)"));
+
+    add((new field_str("reasoning_budget_intro_message"))
+        ->set_desc("Message forced immediately when the reasoning block starts, announcing the token budget. Use {budget} as a placeholder for the configured reasoning_budget_tokens value")
+        ->set_handler([&](field_eval_context & ctx, const json & data) {
+            GGML_ASSERT(ctx.vocab != nullptr);
+            std::string message = data.at("reasoning_budget_intro_message").get<std::string>();
+            const std::string budget_str = std::to_string(ctx.params.sampling.reasoning_budget_tokens);
+            for (size_t pos = 0; (pos = message.find("{budget}", pos)) != std::string::npos; pos += budget_str.size()) {
+                message.replace(pos, 8, budget_str);
+            }
+            ctx.params.sampling.reasoning_budget_intro_forced = common_tokenize(ctx.vocab, message, false, true);
+        }));
+
+    add((new field_num("reasoning_budget_grace_tokens", params.sampling.reasoning_budget_grace_tokens))
+        ->set_hard_limits(0, INT32_MAX)
+        ->set_desc("Once the reasoning budget is exhausted, wait up to this many tokens for a paragraph break before forcing the cutoff (0 = force immediately)"));
 
     add((new field_str("reasoning_budget_start_tag"))
         ->set_desc("Token string marking the start of the reasoning budget section")
@@ -413,18 +435,44 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
         }));
 
     add((new field_str("reasoning_budget_message"))
-        ->set_desc("Message to prepend to the reasoning budget end tag when forcing it")
+        ->set_desc("Message forced when the reasoning budget is exhausted. Should include the model's own closing tag (e.g. </think>) since it is not appended automatically - the exact tag can differ between models/templates. If empty, falls back to forcing just the auto-detected closing tag alone, so the reasoning block still always closes")
         ->set_handler([&](field_eval_context & ctx, const json & data) {
             GGML_ASSERT(ctx.vocab != nullptr);
-            if (!ctx.params.sampling.reasoning_budget_end.empty()) {
-                llama_tokens end_tag = ctx.params.sampling.reasoning_budget_end.front();
-                std::string message = json_value(data, "reasoning_budget_message", std::string());
-                if (!message.empty()) {
-                    llama_tokens message_tokens = common_tokenize(ctx.vocab, message, false, true);
-                    end_tag.insert(end_tag.begin(), message_tokens.begin(), message_tokens.end());
+            std::string message = data.at("reasoning_budget_message").get<std::string>();
+            if (message.empty()) {
+                if (!ctx.params.sampling.reasoning_budget_end.empty()) {
+                    ctx.params.sampling.reasoning_budget_forced = ctx.params.sampling.reasoning_budget_end.front();
                 }
-                ctx.params.sampling.reasoning_budget_forced = std::move(end_tag);
+            } else {
+                ctx.params.sampling.reasoning_budget_forced = common_tokenize(ctx.vocab, message, false, true);
             }
+        }));
+
+    add((new field_str("reasoning_budget_soft_message"))
+        ->set_desc("Soft-warning message injected partway through the reasoning budget, at the next newline boundary")
+        ->set_handler([&](field_eval_context & ctx, const json & data) {
+            GGML_ASSERT(ctx.vocab != nullptr);
+            std::string message = data.at("reasoning_budget_soft_message").get<std::string>();
+            ctx.params.sampling.reasoning_budget_soft_forced = common_tokenize(ctx.vocab, message, false, true);
+        }));
+
+    add((new field_num("reasoning_budget_soft2_ratio", params.sampling.reasoning_budget_soft2_ratio))
+        ->set_hard_limits(-1.0f, 1.0f)
+        ->set_desc("Fraction of the reasoning budget consumed at which to inject the SECOND soft warning message (e.g. 0.5 first, 0.75 second) (<= 0 = disabled)"));
+
+    add((new field_str("reasoning_budget_soft2_message"))
+        ->set_desc("Second soft-warning message, injected partway through the reasoning budget at the next newline boundary")
+        ->set_handler([&](field_eval_context & ctx, const json & data) {
+            GGML_ASSERT(ctx.vocab != nullptr);
+            std::string message = data.at("reasoning_budget_soft2_message").get<std::string>();
+            ctx.params.sampling.reasoning_budget_soft2_forced = common_tokenize(ctx.vocab, message, false, true);
+        }));
+
+    add((new field_str("reasoning_budget_intro_mode"))
+        ->set_desc("When to force the intro message: 'every' = every reasoning block, 'once' = only the first reasoning block of a conversation (deduped against the prompt)")
+        ->set_handler([&](field_eval_context & ctx, const json & data) {
+            ctx.params.sampling.reasoning_budget_intro_mode =
+                data.at("reasoning_budget_intro_mode").get<std::string>();
         }));
 
     add((new field_json("logit_bias"))
@@ -556,11 +604,12 @@ task_params eval_llama_cmpl_schema(
     // debugging
     {
         auto budget = params.sampling.reasoning_budget_tokens;
-        SRV_DBG("reasoning budget: tokens=%d, generation_prompt='%s', start=%zu toks, end=%zu seqs, forced=%zu toks\n",
-                budget, params.sampling.generation_prompt.c_str(),
-                params.sampling.reasoning_budget_start.size(),
-                params.sampling.reasoning_budget_end.size(),
-                params.sampling.reasoning_budget_forced.size());
+        SRV_DBG(
+            "reasoning budget: tokens=%d, generation_prompt='%s', start=%zu toks, end=%zu seqs, forced=%zu toks, soft_ratio=%.2f, soft_forced=%zu toks, intro_forced=%zu toks, grace_tokens=%d\n",
+            budget, params.sampling.generation_prompt.c_str(), params.sampling.reasoning_budget_start.size(),
+            params.sampling.reasoning_budget_end.size(), params.sampling.reasoning_budget_forced.size(),
+            params.sampling.reasoning_budget_soft_ratio, params.sampling.reasoning_budget_soft_forced.size(),
+            params.sampling.reasoning_budget_intro_forced.size(), params.sampling.reasoning_budget_grace_tokens);
     }
 
     return params;

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -362,14 +362,25 @@ json server_task_result_cmpl_final::to_json_non_oaicompat() {
     return response_fields.empty() ? res : json_get_nested_values(response_fields, res);
 }
 
+int32_t server_task_result_cmpl_final::count_reasoning_tokens() {
+    if (n_reasoning_tokens == 0 && vocab_usage && !oaicompat_msg.reasoning_content.empty()) {
+        n_reasoning_tokens = (int32_t) common_tokenize(vocab_usage, oaicompat_msg.reasoning_content, false).size();
+    }
+    return n_reasoning_tokens;
+}
+
 json server_task_result_cmpl_final::usage_json_oaicompat() {
+    const int32_t n_reasoning = count_reasoning_tokens();
     return json {
         {"completion_tokens", n_decoded},
         {"prompt_tokens",     n_prompt_tokens},
         {"total_tokens",      n_decoded + n_prompt_tokens},
         {"prompt_tokens_details", json { {"cached_tokens", n_prompt_tokens_cache} }},
+        {"completion_tokens_details", json { {"reasoning_tokens", n_reasoning} }},
+        {"reasoning", n_reasoning},
     };
 }
+
 
 json server_task_result_cmpl_final::to_json_oaicompat() {
     std::time_t t = std::time(0);
@@ -590,6 +601,8 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp() {
             {"output_tokens", n_decoded},
             {"total_tokens",  n_decoded + n_prompt_tokens},
             {"input_tokens_details", json { {"cached_tokens", n_prompt_tokens_cache} }},
+            {"output_tokens_details", json { {"reasoning_tokens", count_reasoning_tokens() } }},
+            {"reasoning", count_reasoning_tokens()},
         }},
     };
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -320,6 +320,9 @@ struct completion_token_output {
 struct server_task_result_cmpl_final : server_task_result {
     std::string content;
     llama_tokens tokens;
+    const llama_vocab * vocab_usage = nullptr;
+    int32_t n_reasoning_tokens = 0;
+
 
     bool stream;
     bool include_usage;
@@ -374,6 +377,8 @@ struct server_task_result_cmpl_final : server_task_result {
     json to_json_non_oaicompat();
 
     json usage_json_oaicompat();
+    int32_t count_reasoning_tokens();
+
 
     json to_json_oaicompat();
 


### PR DESCRIPTION
Ports the multi-point reasoning budget mechanism from the nudge fork (voidsurfer/llama.cpp-nudge), extending the existing reasoning-budget sampler in the same direction as upstream PR #25961 and beyond:

- master switch `--reasoning-budget-enable` gating the whole mechanism (lazy-grammar suppression keeps working with the switch off)
- forced intro message when a reasoning block starts, with `{budget}` substitution and an intro mode (`every`/`once`); `once` deduplicates against the decoded prompt
- two soft warnings (`--reasoning-budget-soft-ratio/-message`, `--reasoning-budget-soft2-ratio/-message`) fired at newline boundaries once the remaining budget drops below the configured fraction
- bounded grace period (`--reasoning-budget-grace-tokens`) waiting for a paragraph boundary before the hard cutoff, with UTF-8-safe forcing
- reasoning token telemetry: `usage.reasoning`, `usage.completion_tokens_details.reasoning_tokens`, and `output_tokens_details.reasoning_tokens` on Responses
- per-request `reasoning_budget_enabled` override

The port is rebased over the newer upstream sampler work already in this fork (multi-output sampling, multiple end sequences, deep clone, manual forcing, lazy-grammar suppression) and preserves all of it.

AI usage disclosure: implementation ported and reconciled with AI assistance (GLM, `Assisted-by` trailers on the commits); reviewed and tested by the submitter.

Testing:
- `ctest` `test-reasoning-budget` (23 cases) and `test-chat`: pass
- Vulkan Release build (`GGML_VULKAN=ON`)
- smoke on Strix Halo (RADV/Vulkan), Qwen3.8-27B UD-Q6_K_XL: production profile flags parse and serve; live completions report the new telemetry fields
- pi-bench agent task (py-network-debug-senior, single slot, budget 2048): 20+ agent turns, soft2 warning fired at 1179/2048 thinking tokens, prompt cache and spec drafting active throughout, no server errors; task graded 90/100 by the deterministic grader
