### PR TITLE
docs : align issue templates with the fork's AI policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
+++ b/.github/ISSUE_TEMPLATE/010-bug-compilation.yml
@@ -13,7 +13,7 @@ body:
         If the compilation succeeds with ccache disabled you should be able to permanently fix the issue
         by clearing `~/.cache/ccache` (on Linux).
 
-        Please fill out this template yourself, copypasting language model outputs is [strictly prohibited](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
+        AI assistance is allowed in this fork. Disclose how it was used, verify the information in your report, and take responsibility for its accuracy. See [our AI usage policy](https://github.com/halo-box/strix-llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
   - type: textarea
     id: commit
     attributes:

--- a/.github/ISSUE_TEMPLATE/011-bug-results.yml
+++ b/.github/ISSUE_TEMPLATE/011-bug-results.yml
@@ -13,7 +13,7 @@ body:
         please reproduce your issue using one of the examples/binaries in this repository.
         The `llama-completion` binary can be used for simple and reproducible model inference.
 
-        Please fill out this template yourself, copypasting language model outputs is [strictly prohibited](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
+        AI assistance is allowed in this fork. Disclose how it was used, verify the information in your report, and take responsibility for its accuracy. See [our AI usage policy](https://github.com/halo-box/strix-llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
   - type: textarea
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/019-bug-misc.yml
+++ b/.github/ISSUE_TEMPLATE/019-bug-misc.yml
@@ -11,7 +11,7 @@ body:
         If you encountered the issue while using an external UI (e.g. ollama),
         please reproduce your issue using one of the examples/binaries in this repository.
 
-        Please fill out this template yourself, copypasting language model outputs is [strictly prohibited](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
+        AI assistance is allowed in this fork. Disclose how it was used, verify the information in your report, and take responsibility for its accuracy. See [our AI usage policy](https://github.com/halo-box/strix-llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
   - type: textarea
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/020-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/020-enhancement.yml
@@ -8,7 +8,7 @@ body:
       value: |
         [Please post your idea first in Discussion if there is not yet a consensus for this enhancement request. This will help to keep this issue tracker focused on enhancements that the community has agreed needs to be implemented.](https://github.com/ggml-org/llama.cpp/discussions/categories/ideas)
 
-        Please fill out this template yourself, copypasting language model outputs is [strictly prohibited](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
+        AI assistance is allowed in this fork. Disclose how it was used, verify the information in your report, and take responsibility for its accuracy. See [our AI usage policy](https://github.com/halo-box/strix-llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
 
   - type: checkboxes
     id: prerequisites

--- a/.github/ISSUE_TEMPLATE/030-research.yml
+++ b/.github/ISSUE_TEMPLATE/030-research.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Don't forget to check for any [duplicate research issue tickets](https://github.com/ggml-org/llama.cpp/issues?q=is%3Aopen+is%3Aissue+label%3A%22research+%F0%9F%94%AC%22)
 
-        Please fill out this template yourself, copypasting language model outputs is [strictly prohibited](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
+        AI assistance is allowed in this fork. Disclose how it was used, verify the information in your report, and take responsibility for its accuracy. See [our AI usage policy](https://github.com/halo-box/strix-llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
 
   - type: checkboxes
     id: research-stage

--- a/.github/ISSUE_TEMPLATE/040-refactor.yml
+++ b/.github/ISSUE_TEMPLATE/040-refactor.yml
@@ -9,7 +9,7 @@ body:
         Don't forget to [check for existing refactor issue tickets](https://github.com/ggml-org/llama.cpp/issues?q=is%3Aopen+is%3Aissue+label%3Arefactoring) in case it's already covered.
         Also you may want to check [Pull request refactor label as well](https://github.com/ggml-org/llama.cpp/pulls?q=is%3Aopen+is%3Apr+label%3Arefactoring) for duplicates too.
 
-        Please fill out this template yourself, copypasting language model outputs is [strictly prohibited](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
+        AI assistance is allowed in this fork. Disclose how it was used, verify the information in your report, and take responsibility for its accuracy. See [our AI usage policy](https://github.com/halo-box/strix-llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy).
 
   - type: textarea
     id: background-description


### PR DESCRIPTION
## Overview

The six issue forms still prohibit language-model output and link to upstream's AI policy, contradicting this fork's CONTRIBUTING.md and AGENTS.md. #6 updated the contribution guidelines and PR template but left the issue forms unchanged.

Replace the outdated notice in all six forms with consistent guidance that permits AI assistance, asks contributors to disclose its use, verify their report, and take responsibility for its accuracy. Link to this fork's AI usage policy instead of upstream's. All form fields and other guidance remain unchanged.

The Measurements section is omitted because this is documentation-only issue-form text with no runtime or performance impact.

## Additional information

Parsed all six templates as YAML and compared their structure against the originals to confirm every form field is unchanged. `git diff --check` passes. The change is six line replacements.

The exact commit was transferred to Strix over SSH and published from the contributor's personal GitHub account to `ajaxdude/llama.cpp`, a fork in the same repository network. The contribution targets `halo-box/strix-llama.cpp`, not upstream llama.cpp.

## Requirements

- I have read and agree with the [contributing guidelines](CONTRIBUTING.md).
- This change is specific to the Strix Halo fork's AI policy; general llama.cpp improvements belong in [halo-box/llama.cpp](https://github.com/halo-box/llama.cpp) instead.
- AI usage disclosure: AGENT-AUTHORED. GitHub Copilot wrote the changes, commit message, and PR description at the contributor's request. The commit includes Assisted-by and Co-authored-by trailers.
- What was NOT verified: GitHub's rendered issue-form UI was not previewed. No builds, backend tests, or Strix Halo benchmarks were run because only documentation text changed.
