### PR TITLE
ci : add gfx1151 ROCm preflight

### DIFF
--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -7,6 +7,8 @@ on:
       - master
     paths: [
       '.github/workflows/build-self-hosted.yml',
+      'ci/run.sh',
+      'ci/test-rocm-preflight.sh',
       '**/CMakeLists.txt',
       '**/.cmake',
       '**/*.h',
@@ -28,6 +30,8 @@ on:
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-self-hosted.yml',
+      'ci/run.sh',
+      'ci/test-rocm-preflight.sh',
       '**/CMakeLists.txt',
       '**/.cmake',
       '**/*.h',
@@ -88,8 +92,9 @@ jobs:
         # restores correctness. Remove once the underlying ROCm/HIP issue is fixed.
         env:
           HIP_LAUNCH_BLOCKING: "1"
+          GG_BUILD_ROCM_STRIX_PREFLIGHT: "1"
         run: |
-          rocminfo
+          bash ./ci/test-rocm-preflight.sh
           GG_BUILD_ROCM=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-nvidia-cm:

--- a/ci/README.md
+++ b/ci/README.md
@@ -15,6 +15,9 @@ bash ./ci/run.sh ./tmp/results ./tmp/mnt
 # with CUDA support
 GG_BUILD_CUDA=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
+# with ROCm support
+GG_BUILD_ROCM=1 GG_BUILD_AMDGPU_TARGETS=gfx1100 bash ./ci/run.sh ./tmp/results ./tmp/mnt
+
 # with SYCL support
 source /opt/intel/oneapi/setvars.sh
 GG_BUILD_SYCL=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
@@ -24,6 +27,8 @@ GG_BUILD_MUSA=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
 # etc.
 ```
+
+The Strix Halo self-hosted job also sets `GG_BUILD_ROCM_STRIX_PREFLIGHT=1`. This opt-in requires `HIP_LAUNCH_BLOCKING=1`, a `gfx1151` build target, and a working `gfx1151` agent reported by `rocminfo` before the ROCm build starts. Other ROCm runs do not use this device-specific check.
 
 # Adding self-hosted runners
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -13,6 +13,9 @@
 # # with ROCm support
 # GG_BUILD_ROCM=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 #
+# ROCm preflight only
+# HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 bash ./ci/run.sh --rocm-preflight
+#
 # # with SYCL support
 # GG_BUILD_SYCL=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 #
@@ -37,6 +40,78 @@
 # with OPENVINO support
 # GG_BUILD_OPENVINO=1 GG_BUILD_LOW_PERF=1 GGML_OPENVINO_DEVICE=CPU bash ./ci/run.sh ./tmp/results ./tmp/mnt
 #
+
+function gg_rocm_preflight {
+    local targets="${GG_BUILD_AMDGPU_TARGETS:-}"
+    local rocminfo_output
+    local rocminfo_status
+    local hipconfig_output
+    local hipconfig_status
+    local hip_version
+    local runtime_version
+    local agent_name
+
+    echo ">>===== ROCm gfx1151 preflight"
+
+    if [ "${HIP_LAUNCH_BLOCKING:-}" != "1" ]; then
+        echo "ROCm preflight failed: HIP_LAUNCH_BLOCKING must be exactly 1 (got '${HIP_LAUNCH_BLOCKING:-<unset>}')."
+        return 1
+    fi
+
+    if [[ ! "${targets}" =~ (^|[[:space:],;])gfx1151($|[[:space:],;]) ]]; then
+        echo "ROCm preflight failed: GG_BUILD_AMDGPU_TARGETS must include gfx1151 (got '${targets:-<unset>}')."
+        return 1
+    fi
+
+    if ! command -v hipconfig >/dev/null 2>&1; then
+        echo "ROCm preflight failed: hipconfig was not found in PATH."
+        return 1
+    fi
+
+    hipconfig_output=$(hipconfig --version 2>&1)
+    hipconfig_status=$?
+    if [ ${hipconfig_status} -ne 0 ]; then
+        echo "ROCm preflight failed: hipconfig --version exited with status ${hipconfig_status}."
+        printf '%s\n' "${hipconfig_output}" | head -n 10
+        return 1
+    fi
+
+    if ! command -v rocminfo >/dev/null 2>&1; then
+        echo "ROCm preflight failed: rocminfo was not found in PATH."
+        return 1
+    fi
+
+    rocminfo_output=$(rocminfo 2>&1)
+    rocminfo_status=$?
+    if [ ${rocminfo_status} -ne 0 ]; then
+        echo "ROCm preflight failed: rocminfo exited with status ${rocminfo_status}."
+        printf '%s\n' "${rocminfo_output}" | head -n 10
+        return 1
+    fi
+
+    if ! printf '%s\n' "${rocminfo_output}" | grep -Eq '^[[:space:]]*Name:[[:space:]]*gfx1151([[:space:]:]|$)'; then
+        echo "ROCm preflight failed: rocminfo did not report a gfx1151 agent."
+        echo "rocminfo agent names:"
+        printf '%s\n' "${rocminfo_output}" | grep -E '^[[:space:]]*Name:' | head -n 20
+        return 1
+    fi
+
+    hip_version=$(printf '%s\n' "${hipconfig_output}" | head -n 1)
+    runtime_version=$(printf '%s\n' "${rocminfo_output}" | grep -E '^[[:space:]]*Runtime Version:' | head -n 1 | sed -E 's/^[[:space:]]*//')
+    agent_name=$(printf '%s\n' "${rocminfo_output}" | grep -E '^[[:space:]]*Name:[[:space:]]*gfx1151([[:space:]:]|$)' | head -n 1 | sed -E 's/^[[:space:]]*//; s/[[:space:]]+$//')
+
+    echo "ROCm preflight passed:"
+    echo "  HIP_LAUNCH_BLOCKING=1"
+    echo "  GG_BUILD_AMDGPU_TARGETS=${targets}"
+    echo "  HIP version: ${hip_version:-unavailable}"
+    echo "  ${runtime_version:-Runtime Version: unavailable}"
+    echo "  ${agent_name}"
+}
+
+if [ "${1:-}" = "--rocm-preflight" ]; then
+    gg_rocm_preflight
+    exit $?
+fi
 
 if [ -z "$2" ]; then
     echo "usage: $0 <output-dir> <mnt-dir>"
@@ -100,6 +175,10 @@ if [ ! -z ${GG_BUILD_CUDA} ]; then
 fi
 
 if [ ! -z ${GG_BUILD_ROCM} ]; then
+    if [ "${GG_BUILD_ROCM_STRIX_PREFLIGHT:-}" = "1" ]; then
+        gg_rocm_preflight || exit 1
+    fi
+
     CMAKE_EXTRA="${CMAKE_EXTRA} -DCMAKE_HIP_COMPILER=$(hipconfig -l)/clang -DGGML_HIP=ON"
     if [ -z ${GG_BUILD_AMDGPU_TARGETS} ]; then
         echo "Missing GG_BUILD_AMDGPU_TARGETS, please set it to your GPU architecture (e.g. gfx90a, gfx1100, etc.)"

--- a/ci/test-rocm-preflight.sh
+++ b/ci/test-rocm-preflight.sh
@@ -75,8 +75,8 @@ function expect_fail {
     fi
 }
 
-preflight=(bash "${sd}/run.sh" --rocm-preflight)
-stub_env=(env PATH="${tmpdir}/bin:${PATH}")
+preflight=(/bin/bash "${sd}/run.sh" --rocm-preflight)
+stub_env=(env -i PATH="${tmpdir}/bin:/usr/bin:/bin")
 
 expect_pass "valid gfx1151 environment" \
     "${stub_env[@]}" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS='gfx1100;gfx1151' TEST_ROCMINFO_OUTPUT="${rocminfo_gfx1151}" \
@@ -95,11 +95,11 @@ expect_fail "missing gfx1151 agent" "rocminfo did not report a gfx1151 agent" \
     "${preflight[@]}"
 
 expect_fail "missing hipconfig command" "hipconfig was not found in PATH" \
-    env PATH="${tmpdir}/rocm-only" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 \
+    env -i PATH="${tmpdir}/rocm-only" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 \
     /bin/bash "${sd}/run.sh" --rocm-preflight
 
 expect_fail "missing rocminfo command" "rocminfo was not found in PATH" \
-    env PATH="${tmpdir}/hip-only" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 \
+    env -i PATH="${tmpdir}/hip-only" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 \
     /bin/bash "${sd}/run.sh" --rocm-preflight
 
 expect_fail "hipconfig command failure" "hipconfig --version exited with status 6" \
@@ -111,11 +111,11 @@ expect_fail "rocminfo command failure" "rocminfo exited with status 7" \
     "${preflight[@]}"
 
 expect_fail "generic ROCm target validation" "Missing GG_BUILD_AMDGPU_TARGETS" \
-    "${stub_env[@]}" GG_BUILD_ROCM=1 GG_BUILD_ROCM_STRIX_PREFLIGHT= HIP_LAUNCH_BLOCKING= \
-    bash "${sd}/run.sh" "${tmpdir}/results" "${tmpdir}/mnt"
+    "${stub_env[@]}" GG_BUILD_ROCM=1 \
+    /bin/bash "${sd}/run.sh" "${tmpdir}/results" "${tmpdir}/mnt"
 
 expect_fail "self-hosted opt-in before build" "HIP_LAUNCH_BLOCKING must be exactly 1" \
     "${stub_env[@]}" GG_BUILD_ROCM=1 GG_BUILD_ROCM_STRIX_PREFLIGHT=1 HIP_LAUNCH_BLOCKING=0 GG_BUILD_AMDGPU_TARGETS=gfx1151 \
-    bash "${sd}/run.sh" "${tmpdir}/results" "${tmpdir}/mnt"
+    /bin/bash "${sd}/run.sh" "${tmpdir}/results" "${tmpdir}/mnt"
 
 echo "ROCm preflight self-test passed (10 cases)"

--- a/ci/test-rocm-preflight.sh
+++ b/ci/test-rocm-preflight.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sd=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+tmpdir=$(mktemp -d)
+output="${tmpdir}/output.log"
+
+function cleanup {
+    rm -f "${tmpdir}/bin/hipconfig" "${tmpdir}/bin/rocminfo"
+    rm -f "${tmpdir}/hip-only/hipconfig" "${tmpdir}/rocm-only/rocminfo" "${output}"
+    rmdir "${tmpdir}/results" "${tmpdir}/mnt" 2>/dev/null || true
+    rmdir "${tmpdir}/bin" "${tmpdir}/hip-only" "${tmpdir}/rocm-only" "${tmpdir}"
+}
+
+trap cleanup EXIT
+
+mkdir "${tmpdir}/bin" "${tmpdir}/hip-only" "${tmpdir}/rocm-only"
+cat > "${tmpdir}/bin/hipconfig" <<'EOF'
+#!/bin/bash
+printf '%s\n' "${TEST_HIPCONFIG_OUTPUT:-7.1.52802-9999}"
+exit "${TEST_HIPCONFIG_STATUS:-0}"
+EOF
+cat > "${tmpdir}/bin/rocminfo" <<'EOF'
+#!/bin/bash
+printf '%s\n' "${TEST_ROCMINFO_OUTPUT:-}"
+exit "${TEST_ROCMINFO_STATUS:-0}"
+EOF
+chmod +x "${tmpdir}/bin/hipconfig" "${tmpdir}/bin/rocminfo"
+cp "${tmpdir}/bin/hipconfig" "${tmpdir}/hip-only/hipconfig"
+cp "${tmpdir}/bin/rocminfo" "${tmpdir}/rocm-only/rocminfo"
+
+rocminfo_gfx1151='Runtime Version:         1.1
+  Name:                    AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+  Marketing Name:          AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+  Name:                    gfx1151
+  Marketing Name:          AMD Radeon 8060S Graphics'
+
+rocminfo_other='Runtime Version:         1.1
+  Name:                    AMD Ryzen Processor
+  Name:                    gfx1100'
+
+function expect_pass {
+    local name=$1
+    shift
+
+    if ! "$@" > "${output}" 2>&1; then
+        echo "FAIL: ${name}"
+        cat "${output}"
+        exit 1
+    fi
+
+    if ! grep -Fq "ROCm preflight passed" "${output}"; then
+        echo "FAIL: ${name} did not report success"
+        cat "${output}"
+        exit 1
+    fi
+}
+
+function expect_fail {
+    local name=$1
+    local message=$2
+    shift 2
+
+    if "$@" > "${output}" 2>&1; then
+        echo "FAIL: ${name} unexpectedly passed"
+        cat "${output}"
+        exit 1
+    fi
+
+    if ! grep -Fq "${message}" "${output}"; then
+        echo "FAIL: ${name} did not report '${message}'"
+        cat "${output}"
+        exit 1
+    fi
+}
+
+preflight=(bash "${sd}/run.sh" --rocm-preflight)
+stub_env=(env PATH="${tmpdir}/bin:${PATH}")
+
+expect_pass "valid gfx1151 environment" \
+    "${stub_env[@]}" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS='gfx1100;gfx1151' TEST_ROCMINFO_OUTPUT="${rocminfo_gfx1151}" \
+    "${preflight[@]}"
+
+expect_fail "invalid HIP_LAUNCH_BLOCKING" "HIP_LAUNCH_BLOCKING must be exactly 1" \
+    "${stub_env[@]}" HIP_LAUNCH_BLOCKING=0 GG_BUILD_AMDGPU_TARGETS=gfx1151 TEST_ROCMINFO_OUTPUT="${rocminfo_gfx1151}" \
+    "${preflight[@]}"
+
+expect_fail "missing gfx1151 target" "GG_BUILD_AMDGPU_TARGETS must include gfx1151" \
+    "${stub_env[@]}" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx11510 TEST_ROCMINFO_OUTPUT="${rocminfo_gfx1151}" \
+    "${preflight[@]}"
+
+expect_fail "missing gfx1151 agent" "rocminfo did not report a gfx1151 agent" \
+    "${stub_env[@]}" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 TEST_ROCMINFO_OUTPUT="${rocminfo_other}" \
+    "${preflight[@]}"
+
+expect_fail "missing hipconfig command" "hipconfig was not found in PATH" \
+    env PATH="${tmpdir}/rocm-only" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 \
+    /bin/bash "${sd}/run.sh" --rocm-preflight
+
+expect_fail "missing rocminfo command" "rocminfo was not found in PATH" \
+    env PATH="${tmpdir}/hip-only" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 \
+    /bin/bash "${sd}/run.sh" --rocm-preflight
+
+expect_fail "hipconfig command failure" "hipconfig --version exited with status 6" \
+    "${stub_env[@]}" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 TEST_HIPCONFIG_OUTPUT="HIP runtime unavailable" TEST_HIPCONFIG_STATUS=6 \
+    "${preflight[@]}"
+
+expect_fail "rocminfo command failure" "rocminfo exited with status 7" \
+    "${stub_env[@]}" HIP_LAUNCH_BLOCKING=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 TEST_ROCMINFO_OUTPUT="ROCk module is not loaded" TEST_ROCMINFO_STATUS=7 \
+    "${preflight[@]}"
+
+expect_fail "generic ROCm target validation" "Missing GG_BUILD_AMDGPU_TARGETS" \
+    "${stub_env[@]}" GG_BUILD_ROCM=1 GG_BUILD_ROCM_STRIX_PREFLIGHT= HIP_LAUNCH_BLOCKING= \
+    bash "${sd}/run.sh" "${tmpdir}/results" "${tmpdir}/mnt"
+
+expect_fail "self-hosted opt-in before build" "HIP_LAUNCH_BLOCKING must be exactly 1" \
+    "${stub_env[@]}" GG_BUILD_ROCM=1 GG_BUILD_ROCM_STRIX_PREFLIGHT=1 HIP_LAUNCH_BLOCKING=0 GG_BUILD_AMDGPU_TARGETS=gfx1151 \
+    bash "${sd}/run.sh" "${tmpdir}/results" "${tmpdir}/mnt"
+
+echo "ROCm preflight self-test passed (10 cases)"


### PR DESCRIPTION
## Overview

Add an opt-in gfx1151 ROCm preflight before the Strix Halo self-hosted job starts its expensive build and tests.

The preflight requires `HIP_LAUNCH_BLOCKING=1`, an exact `gfx1151` token in `GG_BUILD_AMDGPU_TARGETS`, working `hipconfig` and `rocminfo` commands, and a gfx1151 agent reported by `rocminfo`. It logs concise HIP, HSA runtime, and device evidence and reports configuration failures explicitly.

The self-hosted job enables the check with `GG_BUILD_ROCM_STRIX_PREFLIGHT=1`. Generic ROCm runs and other backends retain their existing behavior. The workflow also runs a focused self-test and includes the affected scripts in its path filters.

The Measurements section is omitted because this change only affects CI checks and documentation, with no inference runtime or performance changes.

## Additional information

Validation performed after merging current `master` (`69946438aa2c432ba365e40bec35c38f6e1de5bb`) into the branch:

- Bash syntax checks and `git diff --check` passed.
- The workflow YAML parsed successfully.
- All 10 controlled self-test cases passed on macOS and Fedora on Strix Halo. Each subprocess uses `env -i`; polluted GitHub Actions, GPU, and stub environment variables cannot trigger a real build or break temporary-directory cleanup.
- A live, model-free Strix preflight passed with HIP `7.1.52802-9999`, HSA Runtime Version `1.1`, and a `gfx1151` agent.
- Deliberately incorrect `HIP_LAUNCH_BLOCKING=0` and `gfx1100` target settings failed with the expected diagnostics on Strix.
- The PR diff after the master merge remains limited to `.github/workflows/build-self-hosted.yml`, `ci/run.sh`, `ci/test-rocm-preflight.sh`, and `ci/README.md`.

No model weights were loaded and no inference was started during validation.

The branch was transferred over SSH and pushed from the contributor's personal GitHub account on Strix.

## Requirements

- I have read and agree with the [contributing guidelines](CONTRIBUTING.md).
- This change is specific to the Strix Halo self-hosted gfx1151 CI job. Generic ROCm behavior is unchanged.
- AI usage disclosure: AGENT-AUTHORED. GitHub Copilot implemented and reviewed the changes and wrote the commit messages and this description at the contributor's request. All agent-authored commits include `Assisted-by: GitHub Copilot` and `Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>` trailers.
- What was NOT verified: no full ROCm build, full backend suite, deterministic model comparison, perplexity run, or performance benchmark was performed for this CI-only change. The self-hosted ROCm workflow is disabled for pull requests, so it cannot validate the branch before merge. No performance or model-output equivalence claim is made.
